### PR TITLE
Update ci testing environment

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -5,15 +5,39 @@ on:
     types: [shared-docker-linux-builders-updated]
 
 jobs:
-  vs-latest-ponyc:
-    name: Verify main against the latest ponyc
+  vs-latest-ponyc-linux:
+    name: Verify main against the latest ponyc om Linux
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.5.2:latest
+    services:
+      postgres:
+        image: postgres:14.5
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: md5
+          POSTGRES_INITDB_ARGS: "--auth-host=md5"
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
-      - uses: actions/checkout@v2
-      - name: Test
-        run: make test config=debug
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Unit tests
+        run: make unit-tests config=debug
+      - name: Integration tests
+        run: make integration-tests config=debug
+        env:
+          POSTGRES_HOST: postgres
+          POSTGRES_PORT: 5432
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DATABASE: postgres
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip@35d7ad8e98444f894dcfe1d4e17332581d28ebeb

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,12 +28,36 @@ jobs:
       - name: Verify CHANGELOG
         run: changelog-tool verify
 
-  vs-ponyc-release-linux:
+  vs-release-ponyc-linux:
     name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.5.2:release
+    services:
+      postgres:
+        image: postgres:14.5
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: md5
+          POSTGRES_INITDB_ARGS: "--auth-host=md5"
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
-      - uses: actions/checkout@v2
-      - name: Test
-        run: make test config=debug
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Unit tests
+        run: make unit-tests config=debug
+      - name: Integration tests
+        run: make integration-tests config=debug
+        env:
+          POSTGRES_HOST: postgres
+          POSTGRES_PORT: 5432
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DATABASE: postgres

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,13 @@ EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -type d))
 EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)
 EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 
-test: unit-tests build-examples
+test: unit-tests integration-tests build-examples
 
 unit-tests: $(tests_binary)
-	$^ --exclude=integration --sequential
+	$^ --exclude=integration/ --sequential
+
+integration-tests: $(tests_binary)
+	$^ --only=integration/ --sequential
 
 $(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -8,4 +8,19 @@ actor \nodoc\ Main is TestList
     None
 
   fun tag tests(test: PonyTest) =>
-    None
+    test(_IntegrationTestToReplace)
+    test(_UnitTestToReplace)
+
+class iso _IntegrationTestToReplace is UnitTest
+  fun name(): String =>
+    "integration/TestToReplace"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(true)
+
+class iso _UnitTestToReplace is UnitTest
+  fun name(): String =>
+    "TestToReplace"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(true)


### PR DESCRIPTION
Previously, we had a generic CI setup that wouldn't work for what is coming with tests that we will start doing based on Red's explorations in his repo.

This commit updates the CI environment to use a builder that has SSL support (for connecting to Postgres) and sets up a dependent Postgres service so we can run integration tests after it.

Additionally, the Makefile has been updated to have an integration-tests target in addition to the unit-tests target.

Finally, two "replace me" tests were added to _test.pony showing how to properly name integration tests vs unit tests so they will be run by their respective Makefile targets.