### PR TITLE
Get basic md5 authentication working

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -4,6 +4,10 @@
   ],
   "deps": [
     {
+      "locator": "github.com/ponylang/crypto.git",
+      "version": "1.1.6"
+    },
+    {
       "locator": "github.com/seantallen-org/lori.git",
       "version": "0.3.0"
     }

--- a/lock.json
+++ b/lock.json
@@ -1,6 +1,10 @@
 {
   "locks": [
     {
+      "locator": "github.com/ponylang/crypto.git",
+      "revision": "1.1.6"
+    },
+    {
       "locator": "github.com/seantallen-org/lori.git",
       "revision": "0.3.0"
     }

--- a/postgres/_authentication_request_type.pony
+++ b/postgres/_authentication_request_type.pony
@@ -1,0 +1,11 @@
+primitive _AuthenticationRequestType
+  """
+  Authentication request types
+
+  See: https://www.postgresql.org/docs/current/protocol-message-formats.html
+  """
+  fun ok(): I32 =>
+    0
+
+  fun md5_password(): I32 =>
+    5

--- a/postgres/_error_code.pony
+++ b/postgres/_error_code.pony
@@ -1,0 +1,8 @@
+primitive _ErrorCode
+  """
+  Error response codes.
+
+  See: https://www.postgresql.org/docs/current/errcodes-appendix.html
+  """
+  fun invalid_password(): String =>
+    "28P01"

--- a/postgres/_error_message.pony
+++ b/postgres/_error_message.pony
@@ -1,0 +1,5 @@
+class val _ErrorMessage
+  let code: String
+
+  new val create(code': String) =>
+    code = code'

--- a/postgres/_error_response_field.pony
+++ b/postgres/_error_response_field.pony
@@ -1,0 +1,8 @@
+primitive _ErrorResponseField
+  """
+  Error response field values
+
+  https://www.postgresql.org/docs/current/protocol-error-fields.html
+  """
+  fun code(): U8 =>
+    'C'

--- a/postgres/_error_response_parser.pony
+++ b/postgres/_error_response_parser.pony
@@ -1,0 +1,23 @@
+primitive _ErrorResponseParser
+  fun apply(payload: Array[U8] val): _ErrorMessage ? =>
+    var code = ""
+    var code_index: USize = 0
+
+    while (payload(code_index)? > 0) do
+      let field_type = payload(code_index)?
+
+      // Find the field terminator. All fields are null terminated.
+      let null_index = payload.find(0, code_index)?
+      let field_index = code_index + 1
+      let field_data = String.from_array(recover
+          payload.slice(field_index, null_index)
+        end)
+
+      if field_type == _ErrorResponseField.code() then
+        code = field_data
+      end
+
+      code_index = null_index + 1
+    end
+
+    _ErrorMessage(code)

--- a/postgres/_md5_password_from_message_payload.pony
+++ b/postgres/_md5_password_from_message_payload.pony
@@ -1,0 +1,16 @@
+use "crypto"
+
+// TODO STA: unit test for this
+primitive _MD5PasswordFromMessagePayload
+  fun apply(message: Array[U8] val, user: String, password: String): String ? =>
+    let salt = recover val
+      [ message(4)? ; message(5)? ; message(6)? ; message(7)? ]
+    end
+
+    // TODO STA
+    // We know the final length of everything so we can improve performance
+    // by not using `+` to build the string
+    ("md5" +
+      ToHexString(MD5(
+        ToHexString(MD5(password + user)) +
+        String.from_array(salt))))

--- a/postgres/_message.pony
+++ b/postgres/_message.pony
@@ -1,0 +1,62 @@
+// TODO STA: need unit tests for each type of message that _Message can generate
+primitive _Message
+  fun startup(user: String, database: String): Array[U8] val ? =>
+    // TODO STA: We can know the length ahead of time and size our array
+    // appropriately and not use push and not need a placeholder for packet
+    // size
+    recover val
+      let msg: Array[U8] = Array[U8]
+      // Placeholder for packet size
+      // This will be set when finish up
+      msg.push_u32(0)
+
+      // Add version numbers.
+      // The version numbers are in network byte order, thus the endian check.
+      ifdef bigendian then
+        msg.push_u16(U16(3)) // Major Version Number
+        msg.push_u16(U16(0)) // Minor Version Number
+      else
+        msg.push_u16(U16(3).bswap()) // Major Version Number
+        msg.push_u16(U16(0).bswap()) // Minor Version Number
+      end
+
+      msg.append("user")
+      msg.push(0)
+      msg.append(user)
+      msg.push(0)
+
+      msg.append("database")
+      msg.push(0)
+      msg.append(database)
+      msg.push(0)
+
+      msg.push(0)
+
+      // Set packet size
+      // The packet size is in written in network byte order, thus the endian
+      // check.
+      ifdef bigendian then
+        msg.update_u32(0, msg.size().u32())?
+      else
+        msg.update_u32(0, msg.size().u32().bswap())?
+      end
+      msg
+    end
+
+  fun password(pwd: String): Array[U8] val =>
+    // TODO STA: We can know the length ahead of time and size our array
+    // appropriately and not use push
+    recover val
+      let msg: Array[U8] = Array[U8]
+      let length = pwd.size().u32() + 5
+      msg.push('p')
+      ifdef bigendian then
+        msg.push_u32(length)
+      else
+        msg.push_u32(length.bswap())
+      end
+
+      msg.append(pwd)
+      msg.push(U8(0))
+      msg
+    end

--- a/postgres/_message_type.pony
+++ b/postgres/_message_type.pony
@@ -1,0 +1,11 @@
+primitive _MessageType
+  """
+  Code that is the first byte of each message.
+
+  See: https://www.postgresql.org/docs/current/protocol-message-formats.html
+  """
+  fun authentication_request(): U8 =>
+    'R'
+
+  fun error_response(): U8 =>
+    'E'

--- a/postgres/pg_session.pony
+++ b/postgres/pg_session.pony
@@ -1,3 +1,4 @@
+use "buffered"
 use lori = "lori"
 
 actor PgSession is lori.TCPClientActor
@@ -10,6 +11,8 @@ actor PgSession is lori.TCPClientActor
   let _database: String
 
   var _connection: lori.TCPConnection = lori.TCPConnection.none()
+
+  let _readbuf: Reader = Reader
 
   new create(
     auth: lori.TCPConnectAuth,
@@ -35,6 +38,85 @@ actor PgSession is lori.TCPClientActor
 
   fun ref on_connected() =>
     _notify.on_connected()
+    _send_startup_message()
 
   fun ref on_failure() =>
     _notify.on_connection_failed()
+
+  fun ref on_received(data: Array[U8] iso) =>
+    _readbuf.append(consume data)
+    _check_for_complete_message()
+
+  fun ref _send_startup_message() =>
+    try
+      let msg = _Message.startup(_user, _database)?
+      _connection.send(msg)
+    else
+      // TODO STA: this should never happen here
+      None
+    end
+
+  fun ref _check_for_complete_message() =>
+    // TODO STA: we can make progress into examining a message and then realize
+    // that there isn't enough. We don't want to redo all the original examining
+    // every single time. We should take an iterative approach storing the state
+    // we have found so far
+
+    // The minimum size for any complete message is 9. If we have less than
+    // 9 received bytes buffered than there is no point to continuing as we
+    // definitely don't have a full message.
+    if _readbuf.size() < 9 then
+      return
+    end
+
+    // TODO STA: this try block is way to long and can hide a ton of errors
+    // during development
+    try
+      let message_type = _readbuf.peek_u8(0)?
+      // payload size includes the 4 bytes for the descriptive header on the
+      // payload.
+      let payload_size = _readbuf.peek_u32_be(1)?.usize() - 4
+      let message_size = payload_size + 4 + 1
+
+      // The message will be `message_size` in length. If we have less than
+      // that then there's no point in continuing.
+      if _readbuf.size() < message_size then
+        return
+      end
+
+      match message_type
+      | _MessageType.authentication_request() =>
+        let auth_type = _readbuf.peek_i32_be(5)?
+
+        if auth_type == _AuthenticationRequestType.ok() then
+          // discard the message and type header
+          _readbuf.skip(message_size)?
+          // notify that we are authenticated
+          _notify.on_authenticated()
+        elseif auth_type == _AuthenticationRequestType.md5_password() then
+          // Slide past the header...
+          _readbuf.skip(5)?
+          // and only get the payload
+          let payload = _readbuf.block(payload_size)?
+          let password = _MD5PasswordFromMessagePayload(consume payload, _user, _password)?
+          let message = _Message.password(password)
+          _connection.send(message)
+        else
+          // TODO STA: unsupported auth type
+          None
+        end
+      | _MessageType.error_response() =>
+        // Slide past the header...
+        _readbuf.skip(5)?
+        // and only get the payload
+        let payload = _readbuf.block(payload_size)?
+        let err = _ErrorResponseParser(consume payload)?
+        if err.code == _ErrorCode.invalid_password() then
+          _notify.on_authentication_failed()
+        end
+      else
+        // TODO STA: unknown message type
+        None
+      end
+    end
+

--- a/postgres/pg_session_notify.pony
+++ b/postgres/pg_session_notify.pony
@@ -12,3 +12,15 @@ interface PgSessionNotify
     authenticate.
     """
     None
+
+  fun ref on_authenticated() =>
+    """
+    Called when we have successfully authenticated with the server.
+    """
+    None
+
+  fun ref on_authentication_failed() =>
+    """
+    Called if we have failed to successfully authenicate with the server.
+    """
+    None


### PR DESCRIPTION
This commit gets basic md5 working. The code is pretty straight line and won't scale well. Parsing knowledge needs to be moved out which is a refactoring that will be coming soon.

There's a bunch of TODOs that have been generated from this as well for unit tests and other additional changes that came from getting the basics working.