### PR TITLE
Add basic state machine mechanism to PgSession

### DIFF
--- a/postgres/_response_parser.pony
+++ b/postgres/_response_parser.pony
@@ -9,14 +9,16 @@ type _ResponseParserResult is
   | _ErrorResponseMessage
   | None )
 
-// TODO STA: we need unit-tests
 primitive _ResponseParser
   """
   Takes a reader that contains buffered responses from a Postgres server and
   extract a single message. To process a full buffer, `apply` should be called in a loop until it returns `None` rather than a message type. The input
   buffer is modified.
+
+  Throws an error if an unrecoverable error is encountered. The session should
+  be shut down in response.
   """
-  fun apply(buffer: Reader): _ResponseParserResult =>
+  fun apply(buffer: Reader): _ResponseParserResult ? =>
     // TODO STA: we can make progress into examining a message and then realize
     // that there isn't enough. We don't want to redo all the original examining
     // every single time. We should take an iterative approach storing the state
@@ -29,60 +31,51 @@ primitive _ResponseParser
       return None
     end
 
-    // TODO STA: this try block is way to long and can hide a ton of errors
-    // during development
-    try
-      let message_type = buffer.peek_u8(0)?
-      // payload size includes the 4 bytes for the descriptive header on the
-      // payload.
-      let payload_size = buffer.peek_u32_be(1)?.usize() - 4
-      let message_size = payload_size + 4 + 1
+    let message_type = buffer.peek_u8(0)?
+    // payload size includes the 4 bytes for the descriptive header on the
+    // payload.
+    let payload_size = buffer.peek_u32_be(1)?.usize() - 4
+    let message_size = payload_size + 4 + 1
 
-      // The message will be `message_size` in length. If we have less than
-      // that then there's no point in continuing.
-      if buffer.size() < message_size then
-        return None
-      end
+    // The message will be `message_size` in length. If we have less than
+    // that then there's no point in continuing.
+    if buffer.size() < message_size then
+      return None
+    end
 
-      match message_type
-      | _MessageType.authentication_request() =>
-        let auth_type = buffer.peek_i32_be(5)?
+    match message_type
+    | _MessageType.authentication_request() =>
+      let auth_type = buffer.peek_i32_be(5)?
 
-        if auth_type == _AuthenticationRequestType.ok() then
-          // discard the message and type header
-          buffer.skip(message_size)?
-          // notify that we are authenticated
-          return _AuthenticationOkMessage
-        elseif auth_type == _AuthenticationRequestType.md5_password() then
-          let salt = String.from_array(
-            recover val
-              [ buffer.peek_u8(9)?
-                buffer.peek_u8(10)?
-                buffer.peek_u8(11)?
-                buffer.peek_u8(12)? ]
-            end)
-          // discard the message now that we've extracted the salt.
-          buffer.skip(message_size)?
+      if auth_type == _AuthenticationRequestType.ok() then
+        // discard the message and type header
+        buffer.skip(message_size)?
+        // notify that we are authenticated
+        return _AuthenticationOkMessage
+      elseif auth_type == _AuthenticationRequestType.md5_password() then
+        let salt = String.from_array(
+          recover val
+            [ buffer.peek_u8(9)?
+              buffer.peek_u8(10)?
+              buffer.peek_u8(11)?
+              buffer.peek_u8(12)? ]
+          end)
+        // discard the message now that we've extracted the salt.
+        buffer.skip(message_size)?
 
-          return _AuthenticationMD5PasswordMessage(salt)
-        else
-          // TODO STA: unsupported auth type
-          return None
-        end
-      | _MessageType.error_response() =>
-        // Slide past the header...
-        buffer.skip(5)?
-        // and only get the payload
-        let payload = buffer.block(payload_size)?
-        return _error_response(consume payload)?
+        return _AuthenticationMD5PasswordMessage(salt)
       else
-        // TODO STA: unsupported message
+        // TODO STA: unsupported auth type
         return None
       end
+    | _MessageType.error_response() =>
+      // Slide past the header...
+      buffer.skip(5)?
+      // and only get the payload
+      let payload = buffer.block(payload_size)?
+      return _error_response(consume payload)?
     else
-      // TODO STA: if we end up here, we are probably screwed. Need to do
-      // something including perhaps indicating that we need to shut down the
-      // session: that would probably throwing our error.
+      // TODO STA: unsupported message
       return None
     end
 

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -9,10 +9,10 @@ class \nodoc\ iso _ResponseParserEmptyBuffer is UnitTest
   fun name(): String =>
     "ResponseParser/EmptyBuffer"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let empty: Reader = Reader
 
-    if _ResponseParser(empty) isnt None then
+    if _ResponseParser(empty)? isnt None then
       h.fail()
     end
 
@@ -24,7 +24,7 @@ class \nodoc\ iso _ResponseParserIncompleteMessage is UnitTest
   fun name(): String =>
     "ResponseParser/IncompleteMessage"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let bytes = _IncomingAuthenticationOkMessage.bytes()
     let complete_message_index = bytes.size()
 
@@ -33,7 +33,7 @@ class \nodoc\ iso _ResponseParserIncompleteMessage is UnitTest
       let s: Array[U8] val = bytes.trim(0, i)
       r.append(s)
 
-      if _ResponseParser(r) isnt None then
+      if _ResponseParser(r)? isnt None then
         h.fail(
           "Parsing incomplete message with size of " +
           i.string() +
@@ -48,12 +48,12 @@ class \nodoc\ iso _ResponseParserAuthenticationOkMessage is UnitTest
   fun name(): String =>
     "ResponseParser/AuthenticationOkMessage"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let bytes = _IncomingAuthenticationOkMessage.bytes()
     let r: Reader = Reader
     r.append(bytes)
 
-    if _ResponseParser(r) isnt _AuthenticationOkMessage then
+    if _ResponseParser(r)? isnt _AuthenticationOkMessage then
       h.fail()
     end
 
@@ -64,13 +64,13 @@ class \nodoc\ iso _ResponseParserAuthenticationMD5PasswordMessage is UnitTest
   fun name(): String =>
     "ResponseParser/AuthenticationMD5PasswordMessage"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let salt = "7669"
     let bytes = _IncomingAuthenticationMD5PasswordMessage(salt).bytes()
     let r: Reader = Reader
     r.append(bytes)
 
-    match _ResponseParser(r)
+    match _ResponseParser(r)?
     | let m: _AuthenticationMD5PasswordMessage =>
       if m.salt != salt then
         h.fail("Salt not correctly parsed.")
@@ -86,13 +86,13 @@ class \nodoc\ iso _ResponseParserErrorResponseMessage is UnitTest
   fun name(): String =>
     "ResponseParser/ErrorResponseMessage"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let code = "7669"
     let bytes = _IncomingErrorResponseMessage(code).bytes()
     let r: Reader = Reader
     r.append(bytes)
 
-    match _ResponseParser(r)
+    match _ResponseParser(r)?
     | let m: _ErrorResponseMessage =>
       if m.code != code then
         h.fail("Code not correctly parsed.")
@@ -111,16 +111,16 @@ class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationOkFirst
   fun name(): String =>
     "ResponseParser/MultipleMessages/AuthenticationOkFirst"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let r: Reader = Reader
     r.append(_IncomingAuthenticationOkMessage.bytes())
     r.append(_IncomingAuthenticationOkMessage.bytes())
 
-    if _ResponseParser(r) isnt _AuthenticationOkMessage then
+    if _ResponseParser(r)? isnt _AuthenticationOkMessage then
       h.fail("Wrong message returned for first message.")
     end
 
-    if _ResponseParser(r) isnt _AuthenticationOkMessage then
+    if _ResponseParser(r)? isnt _AuthenticationOkMessage then
       h.fail("Wrong message returned for second message.")
     end
 
@@ -133,13 +133,13 @@ class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationMD5PasswordFirst
   fun name(): String =>
     "ResponseParser/MultipleMessages/AuthenticationMD5PasswordFirst"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let salt = "7669"
     let r: Reader = Reader
     r.append(_IncomingAuthenticationMD5PasswordMessage(salt).bytes())
     r.append(_IncomingAuthenticationOkMessage.bytes())
 
-    match _ResponseParser(r)
+    match _ResponseParser(r)?
     | let m: _AuthenticationMD5PasswordMessage =>
       if m.salt != salt then
         h.fail("Salt not correctly parsed.")
@@ -148,7 +148,7 @@ class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationMD5PasswordFirst
       h.fail("Wrong message returned for first message.")
     end
 
-    if _ResponseParser(r) isnt _AuthenticationOkMessage then
+    if _ResponseParser(r)? isnt _AuthenticationOkMessage then
       h.fail("Wrong message returned for second message.")
     end
 
@@ -161,13 +161,13 @@ class \nodoc\ iso _ResponseParserMultipleMessagesErrorResponseFirst is UnitTest
   fun name(): String =>
     "ResponseParser/MultipleMessages/ErrorResponseFirst"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let code = "7669"
     let r: Reader = Reader
     r.append(_IncomingErrorResponseMessage(code).bytes())
     r.append(_IncomingAuthenticationOkMessage.bytes())
 
-    match _ResponseParser(r)
+    match _ResponseParser(r)?
     | let m: _ErrorResponseMessage =>
       if m.code != code then
         h.fail("Code not correctly parsed.")
@@ -176,7 +176,7 @@ class \nodoc\ iso _ResponseParserMultipleMessagesErrorResponseFirst is UnitTest
       h.fail("Wrong message returned for first message.")
     end
 
-    if _ResponseParser(r) isnt _AuthenticationOkMessage then
+    if _ResponseParser(r)? isnt _AuthenticationOkMessage then
       h.fail("Wrong message returned for second message.")
     end
 


### PR DESCRIPTION
The state machine is currently using a variable to store where we are in the state machine. This should probably be using the state pattern, but this is a good first step for getting the mechanism in place.

As part of adding the state machine, we have updated to shutdown should we encounter an unrecoverable parsing error.