### PR TITLE
Use state pattern to model PgSession state

### DIFF
--- a/postgres/pg_session.pony
+++ b/postgres/pg_session.pony
@@ -1,97 +1,146 @@
 use "buffered"
 use lori = "lori"
 
-primitive _Unopened
-primitive _Connected
-primitive _LoggedIn
-primitive _Closed
-type _SessionState is (_Unopened | _Connected | _LoggedIn | _Closed)
-
 actor PgSession is lori.TCPClientActor
-  let _auth: lori.TCPConnectAuth
-  let _notify: PgSessionNotify
-  let _host: String
-  let _service: String
-  let _user: String
-  let _password: String
-  let _database: String
+  let notify: PgSessionNotify
+  let host: String
+  let service: String
+  let user: String
+  let password: String
+  let database: String
+
+  let readbuf: Reader = Reader
+  var state: _PgSessionState = _PgSessionUnopened
 
   var _connection: lori.TCPConnection = lori.TCPConnection.none()
-  var _state: _SessionState = _Unopened
-  let _readbuf: Reader = Reader
 
   new create(
-    auth: lori.TCPConnectAuth,
-    notify: PgSessionNotify,
-    host: String,
-    service: String,
-    user: String,
-    password: String,
-    database: String)
+    auth': lori.TCPConnectAuth,
+    notify': PgSessionNotify,
+    host': String,
+    service': String,
+    user': String,
+    password': String,
+    database': String)
   =>
-    _auth = auth
-    _notify = consume notify
-    _host = host
-    _service = service
-    _user = user
-    _password = password
-    _database = database
+    notify = notify'
+    host = host'
+    service = service'
+    user = user'
+    password = password'
+    database = database'
 
-    _connection = lori.TCPConnection.client(auth, host, service, "", this)
+    _connection = lori.TCPConnection.client(auth', host, service, "", this)
 
   fun ref connection(): lori.TCPConnection =>
     _connection
 
   fun ref on_connected() =>
-    _state = _Connected
-    _notify.pg_session_connected(this)
-    _send_startup_message()
+    state.on_connected(this)
 
   fun ref on_failure() =>
-    _state = _Closed
-    _notify.pg_session_connection_failed(this)
+    state.on_failure(this)
 
   fun ref on_received(data: Array[U8] iso) =>
-    _readbuf.append(consume data)
-    _parse_response()
+    state.on_received(this, consume data)
 
-  fun ref _shutdown() =>
+// Possible session states
+primitive _PgSessionUnopened is _ConnectableState
+primitive _PgSessionClosed is (_NotConnectableState & _UnconnectedState)
+primitive _PgSessionConnected is _AuthenticableState
+primitive _PgSessionLoggedIn is (_ConnectedState & _NotAuthenticableState)
+
+interface val _PgSessionState
+  fun on_connected(s: PgSession ref)
     """
-    Shutdown the session.
+    Called when a connection is established with the server.
+    """
+  fun on_failure(s: PgSession ref)
+    """
+    Called if we fail to establish a connection with the server.
+    """
+  fun on_authentication_ok(s: PgSession ref)
+    """
+    Called when we successfully authenticate with the server.
+    """
+  fun on_authentication_failed(s: PgSession ref)
+    """
+    Called if we failed to successfully authenticate with the server.
+    """
+  fun on_authentication_md5_password(s: PgSession ref,
+    msg: _AuthenticationMD5PasswordMessage)
+    """
+    Called if the server requests we autheticate using the Postgres MD5
+    password scheme.
+    """
+  fun shutdown(s: PgSession ref)
+    """
+    Called when we are shutting down the session.
+    """
+  fun on_received(s: PgSession ref, data: Array[U8] iso)
+    """
+    Called when we receive data from the server.
     """
 
-    _readbuf.clear()
-    _connection.close()
-    _state = _Closed
+trait _ConnectableState is _UnconnectedState
+  """
+  An unopened session that can be connected to a server.
+  """
+  fun on_connected(s: PgSession ref) =>
+    s.state = _PgSessionConnected
+    s.notify.pg_session_connected(s)
+    _send_startup_message(s)
 
-  fun ref _send_startup_message() =>
-    // TODO STA: assert that we have a state of _Connected
-    try
-      let msg = _Message.startup(_user, _database)?
-      _connection.send(msg)
+  fun on_failure(s: PgSession ref) =>
+    s.state = _PgSessionClosed
+    s.notify.pg_session_connection_failed(s)
+
+  fun _send_startup_message(s: PgSession ref) =>
+     try
+      let msg = _Message.startup(s.user, s.database)?
+      s.connection().send(msg)
     else
       // TODO STA: this should never happen here
       None
     end
 
-  fun ref _parse_response() =>
+trait _NotConnectableState
+  """
+  A session that if it gets messages related to connect to a server, then
+  something has gone wrong with the state machine.
+  """
+  fun on_connected(s: PgSession ref) =>
+    // TODO STA: die out here if debug
+    None
+
+  fun on_failure(s: PgSession ref) =>
+    // TODO STA: die out here if debug
+    None
+
+trait _ConnectedState is _NotConnectableState
+  """
+  A connected session. Connected sessions are not connectable as they have
+  already been connected.
+  """
+  fun on_received(s: PgSession ref, data: Array[U8] iso) =>
+    s.readbuf.append(consume data)
+    _parse_response(s)
+
+  fun _parse_response(s: PgSession ref) =>
     try
       while true do
-        let message = _ResponseParser(_readbuf)?
+        let message = _ResponseParser(s.readbuf)?
         match message
         | let msg: _AuthenticationMD5PasswordMessage =>
-          let md5_password = _MD5Password(_user, _password, msg.salt)
-          let reply = _Message.password(md5_password)
-          _connection.send(reply)
+          s.state.on_authentication_md5_password(s, msg)
         | _AuthenticationOkMessage =>
-          _state = _LoggedIn
-          _notify.pg_session_authenticated(this)
+          s.state.on_authentication_ok(s)
         | let err: _ErrorResponseMessage =>
           // TODO STA: need to handle invalid_authorization_specification here
           // as well.
           if err.code == _ErrorCode.invalid_password() then
-            _notify.pg_session_authentication_failed(this)
-            _shutdown()
+            s.state.on_authentication_failed(s)
+            shutdown(s)
           end
         | None =>
           // No complete message was found in our received buffer, so we stop
@@ -105,5 +154,65 @@ actor PgSession is lori.TCPClientActor
       // to get the responses back into an understandable state. The only
       // thing we can do is shut this session down.
 
-      _shutdown()
+      shutdown(s)
     end
+
+  fun shutdown(s: PgSession ref) =>
+    s.state = _PgSessionClosed
+    s.readbuf.clear()
+    s.connection().close()
+
+trait _UnconnectedState is _NotAuthenticableState
+  """
+  A session that isn't connected. Either because it was never opened or because
+  it has been closed. Unconnected sessions are not eligible to be authenticated
+  and receiving an authentication event while unconnected is an error.
+  """
+  fun on_received(s: PgSession ref, data: Array[U8] iso) =>
+    // TODO STA: die out here if debug
+    None
+
+  fun shutdown(s: PgSession ref) =>
+    // TODO STA: die out here if debug
+    None
+
+trait _AuthenticableState is _ConnectedState
+  """
+  A session that can be authenticated. All authenticatible sessions are
+  connected sessions, but not all connected sessions are autheticable. Once a
+  session has been authenticated, it's an error for another authetication event
+  to occur.
+  """
+  fun on_authentication_ok(s: PgSession ref) =>
+    s.state = _PgSessionLoggedIn
+    s.notify.pg_session_authenticated(s)
+
+  fun on_authentication_failed(s: PgSession ref) =>
+    s.notify.pg_session_authentication_failed(s)
+    shutdown(s)
+
+  fun on_authentication_md5_password(s: PgSession ref,
+    msg: _AuthenticationMD5PasswordMessage)
+  =>
+      let md5_password = _MD5Password(s.user, s.password, msg.salt)
+      let reply = _Message.password(md5_password)
+      s.connection().send(reply)
+
+trait _NotAuthenticableState
+  """
+  A session that isn't eligible to be authenticated. Only connected sessions
+  that haven't yet been authenticated are eligible to be authenticated.
+  """
+  fun on_authentication_ok(s: PgSession ref) =>
+    // TODO STA: die out here if debug
+    None
+
+  fun on_authentication_failed(s: PgSession ref) =>
+    // TODO STA: die out here if debug
+    None
+
+  fun on_authentication_md5_password(s: PgSession ref,
+    msg: _AuthenticationMD5PasswordMessage)
+  =>
+    // TODO STA: die out here if debug
+    None


### PR DESCRIPTION
With just a small bit of functionality in place, the state transitions in PgSession were fairly clear but you could see the outline of trouble coming.

As an example of "trouble", have a look at TCPConnection in the standard library. Pulling apart the different bits of the state machine in TCPConnection and what is and isn't available for any given state is difficult.

By moving PgSession to the state pattern early, it makes it easy to see what our various state transitions are and what is and isn't possible at each point. During development, I plan on putting "let it crash" exits at any point in the state machine where we encounter unexpected code being called. The state pattern makes these much easier to find as they are very explicit. And those "let it crash" exits will make it easier to find bugs in the code as we develop it.

I've done a couple of interesting things as part of this change. First, all the state handlers are themselves stateless, leaving all state storage to the enclosing PgSession actor. All the state fields in the actor that the state handlers need to access have been made public. By being public we can access them from our state handlers the same as we would from inside the actor. There's no need to add a mass of getters and setters in this case. We simply access the fields as needed. This isn't problematic from an encapsulation standpoint as objects "external to" a PgSession actor can't read it's fields even if they are public. Only objects that we give PgSession ref aliases can access the fields.

We have an interface defined for state handlers, _PgSessionState. The reason we are using an interface rather than a trait comes down to ease of constructing handlers.

We have a series of traits for different bits of state that can change. For example, connected vs not connected, authenticated vs not authenticated, connectable vs not connectable. Each high level state mixes some combination of them together.

The functionality for each is in one or more default methods on the given traits. We need an interface for the overall _PgSessionState so we can have compile time warnings if we try to assign a state handler that hasn't been fully assembled (aka is missing methods). We could use a trait but that then requires an extra `is _PgSessionState`. In the current context, we get little from trait as we will already get compilation errors if any state is missing methods when we try to assign to the `state: _PgSessionState` in the PgSession actor.

I think this has worked out fairly well as we can now easily see our current states:

```pony
primitive _PgSessionUnopened is _ConnectableState
primitive _PgSessionClosed is (_NotConnectableState & _UnconnectedState)
primitive _PgSessionConnected is _AuthenticableState
primitive _PgSessionLoggedIn is (_ConnectedState & _NotAuthenticableState)
```

It would be nice if the states could be made type-safe and to be compile time errors if we try to call a method that is "illegal" for the current state. "Sadly", that isn't possible given the actor based nature of Pony.

An actor can receive a messge from any other actor at any time. There's no way at compile time to prevent an actor sending a message of type X to another actor whose state deems the message "illegal". Further, at the time that a message is sent, it might be "legal" but by the time it is processed, it could be "illegal". Such is the way with asychronous programming. So, we are doing runtime checking. At the moment the "illegal states" are marked by comments in the code that are there as placeholders for me to do something more there. See above for ideas on adding "let it crash" exits.