### PR TITLE
Rename PgSession

### DIFF
--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -36,7 +36,7 @@ class \nodoc\ iso _Authenticate is UnitTest
   fun apply(h: TestHelper) =>
     let info = _TestConnectionConfiguration(h.env.vars)
 
-    let session = PgSession(
+    let session = Session(
       lori.TCPConnectAuth(h.env.root),
       _AuthenticateTestNotify(h, true),
       info.host,
@@ -60,7 +60,7 @@ class \nodoc\ iso _AuthenticateFailure is UnitTest
   fun apply(h: TestHelper) =>
     let info = _TestConnectionConfiguration(h.env.vars)
 
-    let session = PgSession(
+    let session = Session(
       lori.TCPConnectAuth(h.env.root),
       _AuthenticateTestNotify(h, false),
       info.host,
@@ -72,7 +72,7 @@ class \nodoc\ iso _AuthenticateFailure is UnitTest
     h.dispose_when_done(session)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _AuthenticateTestNotify is PgSessionNotify
+actor \nodoc\ _AuthenticateTestNotify is SessionStatusNotify
   let _h: TestHelper
   let _sucess_expected: Bool
 
@@ -80,10 +80,10 @@ actor \nodoc\ _AuthenticateTestNotify is PgSessionNotify
     _h = h
     _sucess_expected = sucess_expected
 
-  be pg_session_authenticated(session: PgSession) =>
+  be pg_session_authenticated(session: Session) =>
     _h.complete(_sucess_expected == true)
 
-  be pg_session_authentication_failed(session: PgSession) =>
+  be pg_session_authentication_failed(session: Session) =>
     _h.complete(_sucess_expected == false)
 
 class \nodoc\ iso _Connect is UnitTest
@@ -97,7 +97,7 @@ class \nodoc\ iso _Connect is UnitTest
   fun apply(h: TestHelper) =>
     let info = _TestConnectionConfiguration(h.env.vars)
 
-    let session = PgSession(
+    let session = Session(
       lori.TCPConnectAuth(h.env.root),
       _ConnectTestNotify(h, true),
       info.host,
@@ -122,7 +122,7 @@ class \nodoc\ iso _ConnectFailure is UnitTest
   fun apply(h: TestHelper) =>
     let info = _TestConnectionConfiguration(h.env.vars)
 
-    let session = PgSession(
+    let session = Session(
       lori.TCPConnectAuth(h.env.root),
       _ConnectTestNotify(h,false),
       info.host,
@@ -134,7 +134,7 @@ class \nodoc\ iso _ConnectFailure is UnitTest
     h.dispose_when_done(session)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _ConnectTestNotify is PgSessionNotify
+actor \nodoc\ _ConnectTestNotify is SessionStatusNotify
   let _h: TestHelper
   let _sucess_expected: Bool
 
@@ -142,10 +142,10 @@ actor \nodoc\ _ConnectTestNotify is PgSessionNotify
     _h = h
     _sucess_expected = sucess_expected
 
-  be pg_session_connected(session: PgSession) =>
+  be pg_session_connected(session: Session) =>
     _h.complete(_sucess_expected == true)
 
-  be pg_session_connection_failed(session: PgSession) =>
+  be pg_session_connection_failed(session: Session) =>
     _h.complete(_sucess_expected == false)
 
 class \nodoc\ val _TestConnectionConfiguration

--- a/postgres/pg_session_notify.pony
+++ b/postgres/pg_session_notify.pony
@@ -1,25 +1,25 @@
-interface tag PgSessionNotify
-  be pg_session_connected(session: PgSession) =>
+interface tag SessionStatusNotify
+  be pg_session_connected(session: Session) =>
     """
     Called when we have connected to the server but haven't yet tried to
     authenticate.
     """
     None
 
-  be pg_session_connection_failed(session: PgSession) =>
+  be pg_session_connection_failed(session: Session) =>
     """
     Called when we have failed to connect to the server before attempting to
     authenticate.
     """
     None
 
-  be pg_session_authenticated(session: PgSession) =>
+  be pg_session_authenticated(session: Session) =>
     """
     Called when we have successfully authenticated with the server.
     """
     None
 
-  be pg_session_authentication_failed(session: PgSession) =>
+  be pg_session_authentication_failed(session: Session) =>
     """
     Called if we have failed to successfully authenicate with the server.
     """


### PR DESCRIPTION
The "Pg" is redundant given that our package is "postgres" and if the user wants to quality names they can do:

```pony
use pg = "postgres"
```

All classes/variables that had Pg as a prefix has been renamed. However, the "pg_" at the beginning of methods on the session status notify remain. I left those as it should be possible to construct an actor that receives session notifications from multiple sources and so, the "pg_" qualifier feels like it makes sense.