### PR TITLE
Add early exit in unexpected situations

### DIFF
--- a/postgres/_mort.pony
+++ b/postgres/_mort.pony
@@ -1,0 +1,33 @@
+use @exit[None](status: U8)
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[U8]]()
+
+primitive _IllegalState
+  """
+  To be used to exit early if we called a function that shouldn't be possible
+  in our current state.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("An illegal state was encountered in %s at line %s\n" +
+       "Please open an issue at https://github.com/ponylang/postgres/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)
+
+primitive _Unreachable
+  """
+  To be used in places that the compiler can't prove is unreachable but we are
+  certain is unreachable and if we reach it, we'd be silently hiding a bug.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("The unreachable was reached in %s at line %s\n" +
+       "Please open an issue at https://github.com/ponylang/postgres/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)

--- a/postgres/pg_session.pony
+++ b/postgres/pg_session.pony
@@ -100,7 +100,7 @@ trait _ConnectableState is _UnconnectedState
       let msg = _Message.startup(s.user, s.database)?
       s._connection().send(msg)
     else
-      // TODO STA: this should never happen here
+      _Unreachable()
       None
     end
 
@@ -110,12 +110,10 @@ trait _NotConnectableState
   something has gone wrong with the state machine.
   """
   fun on_connected(s: Session ref) =>
-    // TODO STA: die out here if debug
-    None
+    _IllegalState()
 
   fun on_failure(s: Session ref) =>
-    // TODO STA: die out here if debug
-    None
+    _IllegalState()
 
 trait _ConnectedState is _NotConnectableState
   """
@@ -169,12 +167,17 @@ trait _UnconnectedState is _NotAuthenticableState
   and receiving an authentication event while unconnected is an error.
   """
   fun on_received(s: Session ref, data: Array[U8] iso) =>
-    // TODO STA: die out here if debug
+    // It is possible we will continue to receive data after we have closed
+    // so this isn't an invalid state. We should silently drop the data. If
+    // "not yet opened" and "closed" were different states, rather than a single
+    // "unconnected" then we would want to call illegal state if `on_received`
+    // was called when the state was "not yet opened".
     None
 
   fun shutdown(s: Session ref) =>
-    // TODO STA: die out here if debug
-    None
+    ifdef debug then
+      _IllegalState()
+    end
 
 trait _AuthenticableState is _ConnectedState
   """
@@ -204,15 +207,12 @@ trait _NotAuthenticableState
   that haven't yet been authenticated are eligible to be authenticated.
   """
   fun on_authentication_ok(s: Session ref) =>
-    // TODO STA: die out here if debug
-    None
+    _IllegalState()
 
   fun on_authentication_failed(s: Session ref) =>
-    // TODO STA: die out here if debug
-    None
+    _IllegalState()
 
   fun on_authentication_md5_password(s: Session ref,
     msg: _AuthenticationMD5PasswordMessage)
   =>
-    // TODO STA: die out here if debug
-    None
+    _IllegalState()


### PR DESCRIPTION
If something happens that we do not expect to happen, then we will potentially exit early depending on how unlikely the thing is.

For now, _IllegalState exists are always on. Before a version 1.0.0, we should make them be only when running debug code.

_Unreachable should always exit as something very very wrong is going on if we hit code that we believe to be unreachable.