### PR TITLE
Add handling all authentication failure types

### DIFF
--- a/postgres/_authentication_failure_reason.pony
+++ b/postgres/_authentication_failure_reason.pony
@@ -1,0 +1,6 @@
+type AuthenticationFailureReason is
+  ( InvalidAuthenticationSpecification
+  | InvalidPassword )
+
+primitive InvalidAuthenticationSpecification
+primitive InvalidPassword

--- a/postgres/_error_code.pony
+++ b/postgres/_error_code.pony
@@ -4,5 +4,8 @@ primitive _ErrorCode
 
   See: https://www.postgresql.org/docs/current/errcodes-appendix.html
   """
+  fun invalid_authentication_specification(): String =>
+    "28000"
+
   fun invalid_password(): String =>
     "28P01"

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -83,7 +83,10 @@ actor \nodoc\ _AuthenticateTestNotify is SessionStatusNotify
   be pg_session_authenticated(session: Session) =>
     _h.complete(_sucess_expected == true)
 
-  be pg_session_authentication_failed(session: Session) =>
+  be pg_session_authentication_failed(
+    s: Session,
+    reason: AuthenticationFailureReason)
+  =>
     _h.complete(_sucess_expected == false)
 
 class \nodoc\ iso _Connect is UnitTest

--- a/postgres/pg_session_notify.pony
+++ b/postgres/pg_session_notify.pony
@@ -19,7 +19,10 @@ interface tag SessionStatusNotify
     """
     None
 
-  be pg_session_authentication_failed(session: Session) =>
+  be pg_session_authentication_failed(
+    session: Session,
+    reason: AuthenticationFailureReason)
+  =>
     """
     Called if we have failed to successfully authenicate with the server.
     """


### PR DESCRIPTION
Previously, we were only notifying and correctly handling invalid
passwords. If we got an "invalid authentication specification" error,
so say, sending MD5 passwords when they aren't supported, we were
silently ignoring.

We now handle both possible authentication errors. As part of this
change, the session status notify interface for authentication failure
takes a second parameter that indicates the kind of failure.

In the Postgres docs, all messages that we get for authentication
are called authentication messages, but the errors use the terminology
"authorization". I've gone with "authentication" throughout this codebase.