### PR TITLE
Rename test classes

### DIFF
--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -11,21 +11,21 @@ actor \nodoc\ Main is TestList
     None
 
   fun tag tests(test: PonyTest) =>
-    test(_Authenticate)
-    test(_AuthenticateFailure)
-    test(_Connect)
-    test(_ConnectFailure)
-    test(_MessagePassword)
-    test(_ResponseParserAuthenticationMD5PasswordMessage)
-    test(_ResponseParserAuthenticationOkMessage)
-    test(_ResponseParserEmptyBuffer)
-    test(_ResponseParserErrorResponseMessage)
-    test(_ResponseParserIncompleteMessage)
-    test(_ResponseParserMultipleMessagesAuthenticationMD5PasswordFirst)
-    test(_ResponseParserMultipleMessagesAuthenticationOkFirst)
-    test(_ResponseParserMultipleMessagesErrorResponseFirst)
+    test(_TestAuthenticate)
+    test(_TestAuthenticateFailure)
+    test(_TestConnect)
+    test(_TestConnectFailure)
+    test(_TestMessagePassword)
+    test(_TestResponseParserAuthenticationMD5PasswordMessage)
+    test(_TestResponseParserAuthenticationOkMessage)
+    test(_TestResponseParserEmptyBuffer)
+    test(_TestResponseParserErrorResponseMessage)
+    test(_TestResponseParserIncompleteMessage)
+    test(_TestResponseParserMultipleMessagesAuthenticationMD5PasswordFirst)
+    test(_TestResponseParserMultipleMessagesAuthenticationOkFirst)
+    test(_TestResponseParserMultipleMessagesErrorResponseFirst)
 
-class \nodoc\ iso _Authenticate is UnitTest
+class \nodoc\ iso _TestAuthenticate is UnitTest
   """
   Test to verify that given correct login information we can authenticate with
   a Postgres server. This test assumes that connecting is working correctly and
@@ -35,7 +35,7 @@ class \nodoc\ iso _Authenticate is UnitTest
     "integration/Authenicate"
 
   fun apply(h: TestHelper) =>
-    let info = _TestConnectionConfiguration(h.env.vars)
+    let info = _ConnectionTestConfiguration(h.env.vars)
 
     let session = Session(
       lori.TCPConnectAuth(h.env.root),
@@ -49,7 +49,7 @@ class \nodoc\ iso _Authenticate is UnitTest
     h.dispose_when_done(session)
     h.long_test(5_000_000_000)
 
-class \nodoc\ iso _AuthenticateFailure is UnitTest
+class \nodoc\ iso _TestAuthenticateFailure is UnitTest
   """
   Test to verify when we fail to authenticate with a Postgres server that are
   handling the failure correctly. This test assumes that connecting is working
@@ -59,7 +59,7 @@ class \nodoc\ iso _AuthenticateFailure is UnitTest
     "integration/AuthenicateFailure"
 
   fun apply(h: TestHelper) =>
-    let info = _TestConnectionConfiguration(h.env.vars)
+    let info = _ConnectionTestConfiguration(h.env.vars)
 
     let session = Session(
       lori.TCPConnectAuth(h.env.root),
@@ -90,7 +90,7 @@ actor \nodoc\ _AuthenticateTestNotify is SessionStatusNotify
   =>
     _h.complete(_sucess_expected == false)
 
-class \nodoc\ iso _Connect is UnitTest
+class \nodoc\ iso _TestConnect is UnitTest
   """
   Test to verify that given correct login information that we can connect to
   a Postgres server.
@@ -99,7 +99,7 @@ class \nodoc\ iso _Connect is UnitTest
     "integration/Connect"
 
   fun apply(h: TestHelper) =>
-    let info = _TestConnectionConfiguration(h.env.vars)
+    let info = _ConnectionTestConfiguration(h.env.vars)
 
     let session = Session(
       lori.TCPConnectAuth(h.env.root),
@@ -113,7 +113,7 @@ class \nodoc\ iso _Connect is UnitTest
     h.dispose_when_done(session)
     h.long_test(5_000_000_000)
 
-class \nodoc\ iso _ConnectFailure is UnitTest
+class \nodoc\ iso _TestConnectFailure is UnitTest
   """
   Test to verify that connection failures are handled correctly. Currently,
   we set up a bad connect attempt by taking the valid port number that would
@@ -124,7 +124,7 @@ class \nodoc\ iso _ConnectFailure is UnitTest
     "integration/ConnectFailure"
 
   fun apply(h: TestHelper) =>
-    let info = _TestConnectionConfiguration(h.env.vars)
+    let info = _ConnectionTestConfiguration(h.env.vars)
 
     let session = Session(
       lori.TCPConnectAuth(h.env.root),
@@ -152,7 +152,7 @@ actor \nodoc\ _ConnectTestNotify is SessionStatusNotify
   be pg_session_connection_failed(session: Session) =>
     _h.complete(_sucess_expected == false)
 
-class \nodoc\ val _TestConnectionConfiguration
+class \nodoc\ val _ConnectionTestConfiguration
   let host: String
   let port: String
   let username: String

--- a/postgres/_test_message.pony
+++ b/postgres/_test_message.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class \nodoc\ iso _MessagePassword is UnitTest
+class \nodoc\ iso _TestMessagePassword is UnitTest
   fun name(): String =>
     "Message/Password"
 

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -1,8 +1,7 @@
 use "buffered"
 use "collections"
 use "pony_test"
-
-class \nodoc\ iso _ResponseParserEmptyBuffer is UnitTest
+class \nodoc\ iso _TestResponseParserEmptyBuffer is UnitTest
   """
   Verify that handling an empty buffer to the parser returns `None`
   """
@@ -16,7 +15,7 @@ class \nodoc\ iso _ResponseParserEmptyBuffer is UnitTest
       h.fail()
     end
 
-class \nodoc\ iso _ResponseParserIncompleteMessage is UnitTest
+class \nodoc\ iso _TestResponseParserIncompleteMessage is UnitTest
   """
   Verify that handing a buffer that isn't a complete message to the parser
   returns `None`
@@ -25,7 +24,7 @@ class \nodoc\ iso _ResponseParserIncompleteMessage is UnitTest
     "ResponseParser/IncompleteMessage"
 
   fun apply(h: TestHelper) ? =>
-    let bytes = _IncomingAuthenticationOkMessage.bytes()
+    let bytes = _IncomingAuthenticationOkTestMessage.bytes()
     let complete_message_index = bytes.size()
 
     for i in Range(0, complete_message_index) do
@@ -41,7 +40,7 @@ class \nodoc\ iso _ResponseParserIncompleteMessage is UnitTest
       end
     end
 
-class \nodoc\ iso _ResponseParserAuthenticationOkMessage is UnitTest
+class \nodoc\ iso _TestResponseParserAuthenticationOkMessage is UnitTest
   """
   Verify that AuthenticationOk messages are parsed correctly
   """
@@ -49,7 +48,7 @@ class \nodoc\ iso _ResponseParserAuthenticationOkMessage is UnitTest
     "ResponseParser/AuthenticationOkMessage"
 
   fun apply(h: TestHelper) ? =>
-    let bytes = _IncomingAuthenticationOkMessage.bytes()
+    let bytes = _IncomingAuthenticationOkTestMessage.bytes()
     let r: Reader = Reader
     r.append(bytes)
 
@@ -57,7 +56,7 @@ class \nodoc\ iso _ResponseParserAuthenticationOkMessage is UnitTest
       h.fail()
     end
 
-class \nodoc\ iso _ResponseParserAuthenticationMD5PasswordMessage is UnitTest
+class \nodoc\ iso _TestResponseParserAuthenticationMD5PasswordMessage is UnitTest
   """
   Verify that AuthenticationMD5Password messages are parsed correctly
   """
@@ -66,7 +65,7 @@ class \nodoc\ iso _ResponseParserAuthenticationMD5PasswordMessage is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let salt = "7669"
-    let bytes = _IncomingAuthenticationMD5PasswordMessage(salt).bytes()
+    let bytes = _IncomingAuthenticationMD5PasswordTestMessage(salt).bytes()
     let r: Reader = Reader
     r.append(bytes)
 
@@ -79,7 +78,7 @@ class \nodoc\ iso _ResponseParserAuthenticationMD5PasswordMessage is UnitTest
       h.fail("Wrong message returned.")
     end
 
-class \nodoc\ iso _ResponseParserErrorResponseMessage is UnitTest
+class \nodoc\ iso _TestResponseParserErrorResponseMessage is UnitTest
   """
   Verify that ErrorResponse messages are parsed correctly
   """
@@ -88,7 +87,7 @@ class \nodoc\ iso _ResponseParserErrorResponseMessage is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let code = "7669"
-    let bytes = _IncomingErrorResponseMessage(code).bytes()
+    let bytes = _IncomingErrorResponseTestMessage(code).bytes()
     let r: Reader = Reader
     r.append(bytes)
 
@@ -101,7 +100,7 @@ class \nodoc\ iso _ResponseParserErrorResponseMessage is UnitTest
       h.fail("Wrong message returned.")
     end
 
-class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationOkFirst
+class \nodoc\ iso _TestResponseParserMultipleMessagesAuthenticationOkFirst
   is UnitTest
   """
   Verify that we correctly advance forward from an authentication ok message
@@ -113,8 +112,8 @@ class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationOkFirst
 
   fun apply(h: TestHelper) ? =>
     let r: Reader = Reader
-    r.append(_IncomingAuthenticationOkMessage.bytes())
-    r.append(_IncomingAuthenticationOkMessage.bytes())
+    r.append(_IncomingAuthenticationOkTestMessage.bytes())
+    r.append(_IncomingAuthenticationOkTestMessage.bytes())
 
     if _ResponseParser(r)? isnt _AuthenticationOkMessage then
       h.fail("Wrong message returned for first message.")
@@ -124,7 +123,8 @@ class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationOkFirst
       h.fail("Wrong message returned for second message.")
     end
 
-class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationMD5PasswordFirst
+class \nodoc\ iso
+  _TestResponseParserMultipleMessagesAuthenticationMD5PasswordFirst
   is UnitTest
   """
   Verify that we correctly advance forward from an authentication md5 password message such that it doesn't corrupt the buffer and lead to an incorrect
@@ -136,8 +136,8 @@ class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationMD5PasswordFirst
   fun apply(h: TestHelper) ? =>
     let salt = "7669"
     let r: Reader = Reader
-    r.append(_IncomingAuthenticationMD5PasswordMessage(salt).bytes())
-    r.append(_IncomingAuthenticationOkMessage.bytes())
+    r.append(_IncomingAuthenticationMD5PasswordTestMessage(salt).bytes())
+    r.append(_IncomingAuthenticationOkTestMessage.bytes())
 
     match _ResponseParser(r)?
     | let m: _AuthenticationMD5PasswordMessage =>
@@ -152,7 +152,7 @@ class \nodoc\ iso _ResponseParserMultipleMessagesAuthenticationMD5PasswordFirst
       h.fail("Wrong message returned for second message.")
     end
 
-class \nodoc\ iso _ResponseParserMultipleMessagesErrorResponseFirst is UnitTest
+class \nodoc\ iso _TestResponseParserMultipleMessagesErrorResponseFirst is UnitTest
   """
   Verify that we correctly advance forward from an error response message such
   that it doesn't corrupt the buffer and lead to an incorrect result for the
@@ -164,8 +164,8 @@ class \nodoc\ iso _ResponseParserMultipleMessagesErrorResponseFirst is UnitTest
   fun apply(h: TestHelper) ? =>
     let code = "7669"
     let r: Reader = Reader
-    r.append(_IncomingErrorResponseMessage(code).bytes())
-    r.append(_IncomingAuthenticationOkMessage.bytes())
+    r.append(_IncomingErrorResponseTestMessage(code).bytes())
+    r.append(_IncomingAuthenticationOkTestMessage.bytes())
 
     match _ResponseParser(r)?
     | let m: _ErrorResponseMessage =>
@@ -180,7 +180,7 @@ class \nodoc\ iso _ResponseParserMultipleMessagesErrorResponseFirst is UnitTest
       h.fail("Wrong message returned for second message.")
     end
 
-class \nodoc\ val _IncomingAuthenticationOkMessage
+class \nodoc\ val _IncomingAuthenticationOkTestMessage
   new val create() =>
     None
 
@@ -198,7 +198,7 @@ class \nodoc\ val _IncomingAuthenticationOkMessage
       out
     end
 
-class \nodoc\ val _IncomingAuthenticationMD5PasswordMessage
+class \nodoc\ val _IncomingAuthenticationMD5PasswordTestMessage
   let _salt: String
 
   new val create(salt: String) =>
@@ -219,7 +219,7 @@ class \nodoc\ val _IncomingAuthenticationMD5PasswordMessage
       out
     end
 
-class \nodoc\ val _IncomingErrorResponseMessage
+class \nodoc\ val _IncomingErrorResponseTestMessage
   let _code: String
 
   new val create(code: String) =>


### PR DESCRIPTION
They had names that were liable to lead to conflicts in the future.