### PR TITLE
Add support for handling unknown message types

### DIFF
--- a/postgres/_response_parser.pony
+++ b/postgres/_response_parser.pony
@@ -7,7 +7,10 @@ type _AuthenticationMessages is
 type _ResponseParserResult is
   ( _AuthenticationMessages
   | _ErrorResponseMessage
+  | UnsupportedMessage
   | None )
+
+primitive UnsupportedMessage
 
 primitive _ResponseParser
   """
@@ -65,8 +68,8 @@ primitive _ResponseParser
 
         return _AuthenticationMD5PasswordMessage(salt)
       else
-        // TODO STA: unsupported auth type
-        return None
+        buffer.skip(message_size)?
+        return UnsupportedMessage
       end
     | _MessageType.error_response() =>
       // Slide past the header...
@@ -75,8 +78,8 @@ primitive _ResponseParser
       let payload = buffer.block(payload_size)?
       return _error_response(consume payload)?
     else
-      // TODO STA: unsupported message
-      return None
+      buffer.skip(message_size)?
+      return UnsupportedMessage
     end
 
   fun _error_response(payload: Array[U8] val): _ErrorResponseMessage ? =>

--- a/postgres/pg_session.pony
+++ b/postgres/pg_session.pony
@@ -148,6 +148,9 @@ trait _ConnectedState is _NotConnectableState
             s.state.on_authentication_failed(s, reason)
             shutdown(s)
           end
+        | UnsupportedMessage =>
+          // Unsupported message of a known type found. Continue on the way.
+          None
         | None =>
           // No complete message was found in our received buffer, so we stop
           // parsing for now.


### PR DESCRIPTION
For message types that we understand, this commit adds support for skipping over ones that we don't understand thereby allowing processing to hopefully proceed properly.