### PR TITLE
Remove race condition impaired test

### DIFF
--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -25,7 +25,6 @@ actor \nodoc\ Main is TestList
     test(_TestQueryAfterAuthenticationFailure)
     test(_TestQueryAfterConnectionFailure)
     test(_TestQueryAfterSessionHasBeenClosed)
-    test(_TestQueryBeforeAuthentication)
     test(_TestQueryResults)
     test(_TestQueryOfNonExistentTable)
     test(_TestResponseParserAuthenticationMD5PasswordMessage)


### PR DESCRIPTION
The test to query before authentication is unreliable as we have no way to set up the condition in a reliable fashion.

I tried two different approaches to fixing this and didn't like either and have removed the test entirely for now.

One approach was to build a dummy server in Pony that would take a connection message and return the "authentication required" and would then have a state machine to handle sending the proper connection message and would then fail the test if it received anything other than a query message. This still might be the preferred approach but it feels like perhaps a "bit too much".

The other option is to test _SessionConnected.execute directly but that requires taking a Session ref which means that we actually need to make Session be an interface we can create new versions and then, because Session is expected to also be a lori. TCPConnection, we have another level of mocking that is needed and that seems entirely too much.