### PR TITLE
Update ponylang/lori dependency to 0.6.0

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
       - name: Unit tests
-        run: make unit-tests config=debug
+        run: make unit-tests config=debug ssl=0.9.0
       - name: Integration tests
-        run: make integration-tests config=debug
+        run: make integration-tests config=debug ssl=0.9.0
         env:
           POSTGRES_HOST: postgres
           POSTGRES_PORT: 5432

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
       - name: Unit tests
-        run: make unit-tests config=debug
+        run: make unit-tests config=debug ssl=0.9.0
       - name: Integration tests
-        run: make integration-tests config=debug
+        run: make integration-tests config=debug ssl=0.9.0
         env:
           POSTGRES_HOST: postgres
           POSTGRES_PORT: 5432

--- a/.release-notes/51.md
+++ b/.release-notes/51.md
@@ -1,0 +1,5 @@
+## Update ponylang/lori dependency to 0.6.0
+
+We've updated the dependency on [ponylang/lori](https://github.com/ponylang/lori) to version 0.6.0. The new version of lori comes with a number of stability improvements that should make this library more reliable in "edge-case scenarios".
+
+The new lori dependency has a transitive dependency on [ponylang/net_ssl](https://github.com/ponylang/net_ssl) and as such, an SSL library is now required to build this library. Please see the [net_ssl installation instructions](https://github.com/ponylang/net_ssl?tab=readme-ov-file#installation) for more information.

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,20 @@ else
 	PONYC = $(COMPILE_WITH) --debug
 endif
 
+ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean start-pg-container stop-pg-container TAGS))
+  ifeq ($(ssl), 3.0.x)
+          SSL = -Dopenssl_3.0.x
+  else ifeq ($(ssl), 1.1.x)
+          SSL = -Dopenssl_1.1.x
+  else ifeq ($(ssl), 0.9.0)
+          SSL = -Dopenssl_0.9.0
+  else
+    $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+  endif
+endif
+
+PONYC := $(PONYC) $(SSL)
+
 SOURCE_FILES := $(shell find $(SRC_DIR) -name *.pony)
 EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -type d))
 EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Please note that if this library encounters a state that the programmers thought
 * `use "postgres"` to include this package
 * `corral run -- ponyc` to compile your application
 
+This library has a transitive dependency on [ponylang/net_ssl](https://github.com/ponylang/net_ssl). It requires a C SSL library to be installed. Please see the [net_ssl installation instructions](https://github.com/ponylang/net_ssl?tab=readme-ov-file#installation) for more information.
+
 ## API Documentation
 
 [https://ponylang.github.io/postgres](https://ponylang.github.io/postgres)

--- a/corral.json
+++ b/corral.json
@@ -9,7 +9,7 @@
     },
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.5.1"
+      "version": "0.6.0"
     }
   ],
   "info": {

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -1,7 +1,7 @@
 use "buffered"
 use lori = "lori"
 
-actor Session is lori.TCPClientActor
+actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   var state: _SessionState
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
 
@@ -20,6 +20,7 @@ actor Session is lori.TCPClientActor
       host',
       service',
       "",
+      this,
       this)
 
   be execute(query: SimpleQuery, receiver: ResultReceiver) =>
@@ -49,6 +50,9 @@ actor Session is lori.TCPClientActor
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _next_lifecycle_event_receiver(): None =>
+    None
 
 // Possible session states
 class ref _SessionUnopened is _ConnectableState


### PR DESCRIPTION
The new version of lori comes with a number of stability fixes as well as new features.

It does however, now require an SSL library to compile and work so, we've had to make adjustments accordingly.

There are also a few small changes to adjust to breaking API changes.