### PR TITLE
Fix typo in SesssionNeverOpened

### DIFF
--- a/.release-notes/fix-session-never-opened-typo.md
+++ b/.release-notes/fix-session-never-opened-typo.md
@@ -1,0 +1,19 @@
+## Fix typo in SesssionNeverOpened
+
+`SesssionNeverOpened` has been renamed to `SessionNeverOpened`.
+
+Before:
+
+```pony
+match error
+| SesssionNeverOpened => "session never opened"
+end
+```
+
+After:
+
+```pony
+match error
+| SessionNeverOpened => "session never opened"
+end
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Only one query is in-flight at a time. The queue serializes execution.
 - `FieldDataTypes` = `(Bool | F32 | F64 | I16 | I32 | I64 | None | String)`
 - `SessionStatusNotify` interface (tag) — lifecycle callbacks (connected, connection_failed, authenticated, authentication_failed, shutdown)
 - `ResultReceiver` interface (tag) — `pg_query_result(Result)`, `pg_query_failed(SimpleQuery, (ErrorResponseMessage | ClientQueryError))`
-- `ClientQueryError` trait — `SesssionNeverOpened` (note: typo is in the codebase), `SessionClosed`, `SessionNotAuthenticated`, `DataError`
+- `ClientQueryError` trait — `SessionNeverOpened`, `SessionClosed`, `SessionNotAuthenticated`, `DataError`
 - `ErrorResponseMessage` — full PostgreSQL error with all standard fields
 - `AuthenticationFailureReason` = `(InvalidAuthenticationSpecification | InvalidPassword)`
 
@@ -126,7 +126,6 @@ Test helpers: `_ConnectionTestConfiguration` reads env vars with defaults. Sever
 - `_test_response_parser.pony:6-13` — TODO: chain-of-messages tests to verify correct buffer advancement across message sequences
 - `result_receiver.pony:1-4` — TODO: consider passing session to result callbacks so receivers without a session tag can execute follow-up queries
 - `_response_parser.pony:161` — Bug: `'R'` error response field sets `builder.line` instead of `builder.routine` (both 'L' and 'R' map to `line`; `routine` is never populated)
-- `query_error.pony:3` — `SesssionNeverOpened` has a typo (three s's); fixing is a breaking change
 
 ## Roadmap
 

--- a/postgres/query_error.pony
+++ b/postgres/query_error.pony
@@ -1,6 +1,6 @@
 trait val ClientQueryError
 
-primitive SesssionNeverOpened is ClientQueryError
+primitive SessionNeverOpened is ClientQueryError
   """
   Error returned when a query is attempted for a session that hasn't been opened
   yet or is in the process of being opened.

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -72,7 +72,7 @@ class ref _SessionUnopened is _ConnectableState
     _database = database'
 
   fun ref execute(s: Session ref, q: SimpleQuery, r: ResultReceiver) =>
-    r.pg_query_failed(q, SesssionNeverOpened)
+    r.pg_query_failed(q, SessionNeverOpened)
 
   fun user(): String =>
     _user


### PR DESCRIPTION
Rename `SesssionNeverOpened` to `SessionNeverOpened`. This is a breaking change to a public type name.

Closes #56