### PR TITLE
Fix ErrorResponseMessage routine field never being populated

### DIFF
--- a/.release-notes/fix-error-response-routine-field.md
+++ b/.release-notes/fix-error-response-routine-field.md
@@ -1,0 +1,3 @@
+## Fix ErrorResponseMessage routine field never being populated
+
+The error response parser incorrectly mapped the `'R'` (Routine) protocol field to `line` instead of `routine` on `ErrorResponseMessage`. The `routine` field was never populated as a result. It now correctly contains the name of the source-code routine that reported the error.

--- a/postgres/_response_parser.pony
+++ b/postgres/_response_parser.pony
@@ -158,7 +158,7 @@ primitive _ResponseParser
       | 'n' => builder.constraint_name = field_data
       | 'F' => builder.file = field_data
       | 'L' => builder.line = field_data
-      | 'R' => builder.line = field_data
+      | 'R' => builder.routine = field_data
       end
 
       code_index = null_index + 1


### PR DESCRIPTION
The error response parser mapped both `'L'` and `'R'` protocol fields to `builder.line`. Per the PostgreSQL protocol spec, `'R'` is the Routine field and should map to `builder.routine`. As a result, `routine` was never populated on `ErrorResponseMessage`.

Closes #57