### PR TITLE
Fix double-delivery of pg_query_failed on failed transactions

### DIFF
--- a/.release-notes/fix-double-delivery.md
+++ b/.release-notes/fix-double-delivery.md
@@ -1,0 +1,3 @@
+## Fix double-delivery of pg_query_failed on failed transactions
+
+When a query error occurred inside a PostgreSQL transaction, the `ResultReceiver` could receive `pg_query_failed` twice for the same query — once with the original error, and again with `SessionClosed` if `close()` was called before the session became idle. The errored query now correctly completes after `ReadyForQuery` regardless of transaction status.

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -412,9 +412,9 @@ actor \nodoc\ _DoesntAnswerTestServer
   Simulates a misbehaving server that authenticates clients but never becomes
   ready for queries. It sends AuthenticationOk but intentionally omits the
   ReadyForQuery message, so the session transitions to _SessionLoggedIn with
-  _queryable stuck at false. Any queued queries are never sent and remain
-  pending until the client calls close(), at which point shutdown drains the
-  queue and delivers SessionClosed failures to each receiver.
+  query_state stuck at _QueryNotReady. Any queued queries are never sent and
+  remain pending until the client calls close(), at which point shutdown
+  drains the queue and delivers SessionClosed failures to each receiver.
   """
   var _authed: Bool = false
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()


### PR DESCRIPTION
Replace the `_queryable`/`_query_in_flight` boolean flags and scattered data fields in `_SessionLoggedIn` with a `_QueryState` sub-state machine that makes illegal query states unrepresentable.

Three concrete states: `_QueryNotReady` (initial, awaiting server readiness), `_QueryReady` (idle, ready to send), `_SimpleQueryInFlight` (query in progress, owns per-query accumulation data). This mirrors the outer session state machine's interface/trait/class pattern and provides a natural extension point for the extended query protocol.

Incidentally fixes a double-delivery bug (#66) where `pg_query_failed` could be called twice on the same receiver when `ReadyForQuery` arrived with non-idle status during an in-flight query.

Design: #64