### PR TITLE
Add parameterized queries via extended query protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Add parameterized queries via extended query protocol ([PR #70](https://github.com/ponylang/postgres/pull/70))
 
 ### Changed
+
+- Change ResultReceiver and Result to use Query union type instead of SimpleQuery ([PR #70](https://github.com/ponylang/postgres/pull/70))
 
 - Update ponylang/ssl dependency ([PR #55](https://github.com/ponylang/postgres/pull/55))
 - Fix typo in SesssionNeverOpened ([PR #59](https://github.com/ponylang/postgres/pull/59))

--- a/examples/query/query-example.pony
+++ b/examples/query/query-example.pony
@@ -47,7 +47,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     // We got a result which for our example program is our trigger to shutdown.
     close()
 
-  be pg_query_failed(query: SimpleQuery,
+  be pg_query_failed(query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _out.print("Query failed.")

--- a/postgres/_backend_messages.pony
+++ b/postgres/_backend_messages.pony
@@ -80,3 +80,43 @@ class val _RowDescriptionMessage
   new val create(columns': Array[(String, U32)] val) =>
     columns = columns'
 
+primitive _ParseCompleteMessage
+  """
+  Message from the backend acknowledging that a Parse command has completed
+  successfully.
+  """
+
+primitive _BindCompleteMessage
+  """
+  Message from the backend acknowledging that a Bind command has completed
+  successfully.
+  """
+
+primitive _CloseCompleteMessage
+  """
+  Message from the backend acknowledging that a Close command has completed
+  successfully.
+  """
+
+primitive _NoDataMessage
+  """
+  Message from the backend indicating that the described statement or portal
+  will not return rows.
+  """
+
+class val _ParameterDescriptionMessage
+  """
+  Message from the backend describing the parameter types of a prepared
+  statement. Sent in response to a Describe(Statement) command.
+  """
+  let param_oids: Array[U32] val
+
+  new val create(param_oids': Array[U32] val) =>
+    param_oids = param_oids'
+
+primitive _PortalSuspendedMessage
+  """
+  Message from the backend indicating that an Execute command has been
+  suspended because the specified maximum row count was reached.
+  """
+

--- a/postgres/_frontend_message.pony
+++ b/postgres/_frontend_message.pony
@@ -80,3 +80,213 @@ primitive _FrontendMessage
       _Unreachable()
       []
     end
+
+  fun parse(name: String, query_string: String,
+    param_type_oids: Array[U32] val): Array[U8] val
+  =>
+    """
+    Build a Parse message for the extended query protocol.
+
+    Format: Byte1('P') Int32(len) String(name) String(query)
+            Int16(num_param_types) Int32[](param_type_oids)
+    """
+    try
+      recover val
+        // 1 type + 4 length + name + null + query + null + 2 num_params
+        // + (4 * num_oids)
+        let length: U32 = 4 + name.size().u32() + 1
+          + query_string.size().u32() + 1 + 2
+          + (param_type_oids.size().u32() * 4)
+        let msg_size = (length + 1).usize()
+        let msg: Array[U8] = Array[U8].init(0, msg_size)
+        msg.update_u8(0, 'P')?
+        ifdef bigendian then
+          msg.update_u32(1, length)?
+        else
+          msg.update_u32(1, length.bswap())?
+        end
+        var offset: USize = 5
+        msg.copy_from(name.array(), 0, offset, name.size())
+        offset = offset + name.size() + 1 // null terminator from init
+        msg.copy_from(query_string.array(), 0, offset, query_string.size())
+        offset = offset + query_string.size() + 1
+        ifdef bigendian then
+          msg.update_u16(offset, param_type_oids.size().u16())?
+        else
+          msg.update_u16(offset, param_type_oids.size().u16().bswap())?
+        end
+        offset = offset + 2
+        for oid in param_type_oids.values() do
+          ifdef bigendian then
+            msg.update_u32(offset, oid)?
+          else
+            msg.update_u32(offset, oid.bswap())?
+          end
+          offset = offset + 4
+        end
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end
+
+  fun bind(portal: String, stmt: String,
+    params: Array[(String | None)] val): Array[U8] val
+  =>
+    """
+    Build a Bind message for the extended query protocol.
+
+    Format: Byte1('B') Int32(len) String(portal) String(stmt)
+            Int16(0) Int16(num_params) [Int32(val_len) Byte[](val)]*
+            Int16(0)
+
+    All parameters use text format (num_param_formats = 0 shorthand).
+    NULL parameters have val_len = -1 with no value bytes.
+    """
+    try
+      recover val
+        // Calculate params payload size
+        var params_size: USize = 0
+        for p in params.values() do
+          params_size = params_size + 4 // val_len field
+          match p
+          | let s: String => params_size = params_size + s.size()
+          end
+        end
+        // 1 type + 4 length + portal + null + stmt + null
+        // + 2 num_param_formats + 2 num_params + params_size
+        // + 2 num_result_formats
+        let length: U32 = 4 + portal.size().u32() + 1 + stmt.size().u32() + 1
+          + 2 + 2 + params_size.u32() + 2
+        let msg_size = (length + 1).usize()
+        let msg: Array[U8] = Array[U8].init(0, msg_size)
+        msg.update_u8(0, 'B')?
+        ifdef bigendian then
+          msg.update_u32(1, length)?
+        else
+          msg.update_u32(1, length.bswap())?
+        end
+        var offset: USize = 5
+        msg.copy_from(portal.array(), 0, offset, portal.size())
+        offset = offset + portal.size() + 1
+        msg.copy_from(stmt.array(), 0, offset, stmt.size())
+        offset = offset + stmt.size() + 1
+        // num_param_formats = 0 (all text shorthand) — already zero from init
+        offset = offset + 2
+        // num_params
+        ifdef bigendian then
+          msg.update_u16(offset, params.size().u16())?
+        else
+          msg.update_u16(offset, params.size().u16().bswap())?
+        end
+        offset = offset + 2
+        for p in params.values() do
+          match p
+          | let s: String =>
+            ifdef bigendian then
+              msg.update_u32(offset, s.size().u32())?
+            else
+              msg.update_u32(offset, s.size().u32().bswap())?
+            end
+            offset = offset + 4
+            msg.copy_from(s.array(), 0, offset, s.size())
+            offset = offset + s.size()
+          | None =>
+            // NULL: val_len = -1 (0xFFFFFFFF as unsigned)
+            ifdef bigendian then
+              msg.update_u32(offset, U32.max_value())?
+            else
+              msg.update_u32(offset, U32.max_value().bswap())?
+            end
+            offset = offset + 4
+          end
+        end
+        // num_result_formats = 0 (all text shorthand) — already zero from init
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end
+
+  fun describe_portal(portal: String): Array[U8] val =>
+    """
+    Build a Describe message for a portal.
+
+    Format: Byte1('D') Int32(len) Byte1('P') String(portal)
+    """
+    try
+      recover val
+        // 1 type + 4 length + 1 indicator + portal + null
+        let length: U32 = 4 + 1 + portal.size().u32() + 1
+        let msg_size = (length + 1).usize()
+        let msg: Array[U8] = Array[U8].init(0, msg_size)
+        msg.update_u8(0, 'D')?
+        ifdef bigendian then
+          msg.update_u32(1, length)?
+        else
+          msg.update_u32(1, length.bswap())?
+        end
+        msg.update_u8(5, 'P')?
+        msg.copy_from(portal.array(), 0, 6, portal.size())
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end
+
+  fun execute_msg(portal: String, max_rows: U32): Array[U8] val =>
+    """
+    Build an Execute message.
+
+    Format: Byte1('E') Int32(len) String(portal) Int32(max_rows)
+    """
+    try
+      recover val
+        // 1 type + 4 length + portal + null + 4 max_rows
+        let length: U32 = 4 + portal.size().u32() + 1 + 4
+        let msg_size = (length + 1).usize()
+        let msg: Array[U8] = Array[U8].init(0, msg_size)
+        msg.update_u8(0, 'E')?
+        ifdef bigendian then
+          msg.update_u32(1, length)?
+        else
+          msg.update_u32(1, length.bswap())?
+        end
+        msg.copy_from(portal.array(), 0, 5, portal.size())
+        let max_rows_offset = 5 + portal.size() + 1
+        ifdef bigendian then
+          msg.update_u32(max_rows_offset, max_rows)?
+        else
+          msg.update_u32(max_rows_offset, max_rows.bswap())?
+        end
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end
+
+  fun sync(): Array[U8] val =>
+    """
+    Build a Sync message.
+
+    Format: Byte1('S') Int32(4)
+    """
+    try
+      recover val
+        let msg: Array[U8] = Array[U8].init(0, 5)
+        msg.update_u8(0, 'S')?
+        ifdef bigendian then
+          msg.update_u32(1, U32(4))?
+        else
+          msg.update_u32(1, U32(4).bswap())?
+        end
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -41,10 +41,30 @@ actor \nodoc\ Main is TestList
     test(_TestResponseParserMultipleMessagesErrorResponseFirst)
     test(_TestResponseParserReadyForQueryMessage)
     test(_TestResponseParserRowDescriptionMessage)
+    test(_TestResponseParserParseCompleteMessage)
+    test(_TestResponseParserBindCompleteMessage)
+    test(_TestResponseParserNoDataMessage)
+    test(_TestResponseParserCloseCompleteMessage)
+    test(_TestResponseParserParameterDescriptionMessage)
+    test(_TestResponseParserPortalSuspendedMessage)
+    test(_TestResponseParserDigitMessageTypeNotJunk)
+    test(_TestResponseParserMultipleMessagesParseCompleteFirst)
+    test(_TestFrontendMessageParse)
+    test(_TestFrontendMessageParseWithTypes)
+    test(_TestFrontendMessageBind)
+    test(_TestFrontendMessageBindWithNull)
+    test(_TestFrontendMessageDescribePortal)
+    test(_TestFrontendMessageExecute)
+    test(_TestFrontendMessageSync)
     test(_TestUnansweredQueriesFailOnShutdown)
     test(_TestZeroRowSelectReturnsResultSet)
     test(_TestZeroRowSelect)
     test(_TestMultiStatementMixedResults)
+    test(_TestPreparedQueryResults)
+    test(_TestPreparedQueryNullParam)
+    test(_TestPreparedQueryNonExistentTable)
+    test(_TestPreparedQueryInsertAndDelete)
+    test(_TestPreparedQueryMixedWithSimple)
 
 class \nodoc\ iso _TestAuthenticate is UnitTest
   """
@@ -315,7 +335,7 @@ class \nodoc\ iso _TestUnansweredQueriesFailOnShutdown is UnitTest
 
 actor \nodoc\ _DoesntAnswerClient is (SessionStatusNotify & ResultReceiver)
   let _h: TestHelper
-  let _in_flight_queries: SetIs[SimpleQuery] = _in_flight_queries.create()
+  let _in_flight_queries: SetIs[Query] = _in_flight_queries.create()
 
   new create(h: TestHelper) =>
     _h = h
@@ -340,7 +360,7 @@ actor \nodoc\ _DoesntAnswerClient is (SessionStatusNotify & ResultReceiver)
     _h.fail("Unexpectedly got a result for a query.")
     _h.complete(false)
 
-  be pg_query_failed(query: SimpleQuery,
+  be pg_query_failed(query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     if _in_flight_queries.contains(query) then
@@ -513,7 +533,7 @@ actor \nodoc\ _ZeroRowSelectTestClient is (SessionStatusNotify & ResultReceiver)
 
     _close_and_complete(true)
 
-  be pg_query_failed(query: SimpleQuery,
+  be pg_query_failed(query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure.")

--- a/postgres/_test_frontend_message.pony
+++ b/postgres/_test_frontend_message.pony
@@ -46,3 +46,125 @@ class \nodoc\ iso _TestFrontendMessageStartup is UnitTest
     end
 
     h.assert_array_eq[U8](expected, _FrontendMessage.startup(username, password))
+
+class \nodoc\ iso _TestFrontendMessageParse is UnitTest
+  fun name(): String =>
+    "FrontendMessage/Parse"
+
+  fun apply(h: TestHelper) =>
+    // Parse("", "S $1", [])
+    // Length = 4 + 0+1 + 4+1 + 2 + 0 = 12, total = 13
+    let expected: Array[U8] = ifdef bigendian then
+      [ 80; 12; 0; 0; 0; 0; 83; 32; 36; 49; 0; 0; 0 ]
+    else
+      [ 80; 0; 0; 0; 12; 0; 83; 32; 36; 49; 0; 0; 0 ]
+    end
+
+    let oids: Array[U32] val = recover val Array[U32] end
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.parse("", "S $1", oids))
+
+class \nodoc\ iso _TestFrontendMessageParseWithTypes is UnitTest
+  fun name(): String =>
+    "FrontendMessage/ParseWithTypes"
+
+  fun apply(h: TestHelper) =>
+    // Parse("", "S $1", [23])
+    // Length = 4 + 0+1 + 4+1 + 2 + 4 = 16, total = 17
+    let expected: Array[U8] = ifdef bigendian then
+      [ 80; 16; 0; 0; 0; 0; 83; 32; 36; 49; 0; 1; 0; 23; 0; 0; 0 ]
+    else
+      [ 80; 0; 0; 0; 16; 0; 83; 32; 36; 49; 0; 0; 1; 0; 0; 0; 23 ]
+    end
+
+    let oids: Array[U32] val = recover val [as U32: 23] end
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.parse("", "S $1", oids))
+
+class \nodoc\ iso _TestFrontendMessageBind is UnitTest
+  fun name(): String =>
+    "FrontendMessage/Bind"
+
+  fun apply(h: TestHelper) =>
+    // Bind("", "", ["abc"])
+    // params_size = 4+3 = 7
+    // Length = 4 + 0+1 + 0+1 + 2 + 2 + 7 + 2 = 19, total = 20
+    let expected: Array[U8] = ifdef bigendian then
+      [ 66; 19; 0; 0; 0; 0; 0; 0; 0; 1; 0
+        3; 0; 0; 0; 97; 98; 99; 0; 0 ]
+    else
+      [ 66; 0; 0; 0; 19; 0; 0; 0; 0; 0; 1
+        0; 0; 0; 3; 97; 98; 99; 0; 0 ]
+    end
+
+    let params: Array[(String | None)] val = recover val ["abc"] end
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.bind("", "", params))
+
+class \nodoc\ iso _TestFrontendMessageBindWithNull is UnitTest
+  fun name(): String =>
+    "FrontendMessage/BindWithNull"
+
+  fun apply(h: TestHelper) =>
+    // Bind("", "", [None])
+    // params_size = 4
+    // Length = 4 + 0+1 + 0+1 + 2 + 2 + 4 + 2 = 16, total = 17
+    let expected: Array[U8] = ifdef bigendian then
+      [ 66; 16; 0; 0; 0; 0; 0; 0; 0; 1; 0
+        255; 255; 255; 255; 0; 0 ]
+    else
+      [ 66; 0; 0; 0; 16; 0; 0; 0; 0; 0; 1
+        255; 255; 255; 255; 0; 0 ]
+    end
+
+    let params: Array[(String | None)] val = recover val [None] end
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.bind("", "", params))
+
+class \nodoc\ iso _TestFrontendMessageDescribePortal is UnitTest
+  fun name(): String =>
+    "FrontendMessage/DescribePortal"
+
+  fun apply(h: TestHelper) =>
+    // DescribePortal("")
+    // Length = 4 + 1 + 0+1 = 6, total = 7
+    let expected: Array[U8] = ifdef bigendian then
+      [ 68; 6; 0; 0; 0; 80; 0 ]
+    else
+      [ 68; 0; 0; 0; 6; 80; 0 ]
+    end
+
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.describe_portal(""))
+
+class \nodoc\ iso _TestFrontendMessageExecute is UnitTest
+  fun name(): String =>
+    "FrontendMessage/Execute"
+
+  fun apply(h: TestHelper) =>
+    // ExecuteMsg("", 0)
+    // Length = 4 + 0+1 + 4 = 9, total = 10
+    let expected: Array[U8] = ifdef bigendian then
+      [ 69; 9; 0; 0; 0; 0; 0; 0; 0; 0 ]
+    else
+      [ 69; 0; 0; 0; 9; 0; 0; 0; 0; 0 ]
+    end
+
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.execute_msg("", 0))
+
+class \nodoc\ iso _TestFrontendMessageSync is UnitTest
+  fun name(): String =>
+    "FrontendMessage/Sync"
+
+  fun apply(h: TestHelper) =>
+    // Sync()
+    // Length = 4, total = 5
+    let expected: Array[U8] = ifdef bigendian then
+      [ 83; 4; 0; 0; 0 ]
+    else
+      [ 83; 0; 0; 0; 4 ]
+    end
+
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.sync())

--- a/postgres/prepared_query.pony
+++ b/postgres/prepared_query.pony
@@ -1,0 +1,16 @@
+class val PreparedQuery
+  """
+  A parameterized query using PostgreSQL's extended query protocol.
+  Parameters are referenced as $1, $2, ... in the query string.
+  Values are sent in text format; use None for NULL.
+
+  The query string must contain a single SQL statement. Multi-statement
+  queries are not supported by the extended query protocol; use SimpleQuery
+  for multi-statement execution.
+  """
+  let string: String
+  let params: Array[(String | None)] val
+
+  new val create(string': String, params': Array[(String | None)] val) =>
+    string = string'
+    params = params'

--- a/postgres/query.pony
+++ b/postgres/query.pony
@@ -1,0 +1,6 @@
+type Query is (SimpleQuery | PreparedQuery)
+  """
+  A query that can be executed via `Session.execute()`. SimpleQuery uses the
+  simple query protocol (unparameterized); PreparedQuery uses the extended
+  query protocol (parameterized).
+  """

--- a/postgres/result.pony
+++ b/postgres/result.pony
@@ -1,12 +1,12 @@
 trait val Result
-  fun query(): SimpleQuery
+  fun query(): Query
 
 class val ResultSet is Result
-  let _query: SimpleQuery
+  let _query: Query
   let _rows: Rows
   let _command: String
 
-  new val create(query': SimpleQuery,
+  new val create(query': Query,
     rows': Rows,
     command': String)
   =>
@@ -14,7 +14,7 @@ class val ResultSet is Result
     _rows = rows'
     _command = command'
 
-  fun query(): SimpleQuery =>
+  fun query(): Query =>
     _query
 
   fun rows(): Rows =>
@@ -24,20 +24,20 @@ class val ResultSet is Result
     _command
 
 class val SimpleResult is Result
-  let _query: SimpleQuery
+  let _query: Query
 
-  new val create(query': SimpleQuery) =>
+  new val create(query': Query) =>
     _query = query'
 
-  fun query(): SimpleQuery =>
+  fun query(): Query =>
     _query
 
 class val RowModifying is Result
-  let _query: SimpleQuery
+  let _query: Query
   let _command: String
   let _impacted: USize
 
-  new val create(query': SimpleQuery,
+  new val create(query': Query,
     command': String,
     impacted': USize)
   =>
@@ -45,7 +45,7 @@ class val RowModifying is Result
     _command = command'
     _impacted = impacted'
 
-  fun query(): SimpleQuery =>
+  fun query(): Query =>
     _query
 
   fun command(): String =>

--- a/postgres/result_receiver.pony
+++ b/postgres/result_receiver.pony
@@ -7,6 +7,6 @@ interface tag ResultReceiver
     """
     """
 
-  be pg_query_failed(query: SimpleQuery, failure: (ErrorResponseMessage | ClientQueryError))
+  be pg_query_failed(query: Query, failure: (ErrorResponseMessage | ClientQueryError))
     """
     """


### PR DESCRIPTION
Implements `PreparedQuery` using PostgreSQL's extended query protocol (Parse, Bind, Describe, Execute, Sync). Parameters are text-format with server-inferred types, using unnamed prepared statements.

This is a breaking change: `ResultReceiver.pg_query_failed` and `Result.query()` now use the `Query` union type (`SimpleQuery | PreparedQuery`) instead of `SimpleQuery` directly.

Design: #62