### PR TITLE
Update ponylang/lori dependency to 0.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 1.0.1 (MD5 password hashing via `ssl/crypto`)
-- `ponylang/lori` 0.6.2 (TCP networking)
+- `ponylang/lori` 0.7.0 (TCP networking)
 
 Managed via `corral`.
 

--- a/corral.json
+++ b/corral.json
@@ -9,7 +9,7 @@
     },
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.6.2"
+      "version": "0.7.0"
     }
   ],
   "info": {

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -300,9 +300,6 @@ actor \nodoc\ _JunkSendingTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): None =>
-    None
-
   fun ref _on_received(data: Array[U8] iso) =>
     let junk = _IncomingJunkTestMessage.bytes()
     _tcp_connection.send(junk)
@@ -444,9 +441,6 @@ actor \nodoc\ _DoesntAnswerTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
-
-  fun ref _next_lifecycle_event_receiver(): None =>
-    None
 
   fun ref _on_received(data: Array[U8] iso) =>
     """
@@ -598,9 +592,6 @@ actor \nodoc\ _ZeroRowSelectTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
-
-  fun ref _next_lifecycle_event_receiver(): None =>
-    None
 
   fun ref _on_received(data: Array[U8] iso) =>
     _received_count = _received_count + 1

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -51,9 +51,6 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): None =>
-    None
-
 // Possible session states
 class ref _SessionUnopened is _ConnectableState
   let _notify: SessionStatusNotify


### PR DESCRIPTION
lori 0.7.0 removed the lifecycle event receiver chaining API (`_next_lifecycle_event_receiver()` / `_on_send()` / `_on_expect_set()`). The only required code change is removing `_next_lifecycle_event_receiver()` from `Session` and three test server actors.

Other lori 0.7.0 changes (fallible `send()`, SSL API redesign, new callbacks) don't require postgres changes — `send()` fire-and-forget still compiles, postgres doesn't use SSL, and new callbacks have default no-op implementations.

No public API changes to postgres.