### PR TITLE
Fix connection failure tests hanging on WSL2 mirrored networking

### DIFF
--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -166,11 +166,12 @@ class \nodoc\ iso _TestConnectFailure is UnitTest
 
   fun apply(h: TestHelper) =>
     let info = _ConnectionTestConfiguration(h.env.vars)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
 
     let session = Session(
       lori.TCPConnectAuth(h.env.root),
       _ConnectTestNotify(h, false),
-      info.host,
+      host,
       info.port.reverse(),
       info.username,
       info.password,

--- a/postgres/_test_query.pony
+++ b/postgres/_test_query.pony
@@ -154,11 +154,12 @@ class \nodoc\ iso _TestQueryAfterConnectionFailure is UnitTest
 
   fun apply(h: TestHelper) =>
     let info = _ConnectionTestConfiguration(h.env.vars)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
 
     let session = Session(
       lori.TCPConnectAuth(h.env.root),
       _QueryAfterConnectionFailureNotify(h),
-      info.host,
+      host,
       info.port.reverse(),
       info.username,
       info.password,


### PR DESCRIPTION
WSL2 mirrored networking has a Hyper-V bug (Microsoft WSL issue #10855) where connecting to 127.0.0.1 on a port with nothing listening hangs indefinitely — RST packets get corrupted destination ports and are dropped by the kernel. The two connection failure tests (_TestConnectFailure, _TestQueryAfterConnectionFailure) intentionally connect to a port with nothing listening, triggering this bug.

Uses the same workaround as ponylang/lori PR #153: connect to 127.0.0.2 on Linux (stays within the Linux kernel, bypasses Hyper-V) and localhost on other platforms (127.0.0.2 isn't on macOS loopback by default).