### PR TITLE
Add named prepared statement support

### DIFF
--- a/.release-notes/add-named-prepared-statements.md
+++ b/.release-notes/add-named-prepared-statements.md
@@ -1,0 +1,29 @@
+## Add named prepared statement support
+
+You can now create server-side named prepared statements with `Session.prepare()`, execute them with `NamedPreparedQuery`, and destroy them with `Session.close_statement()`. Named statements are parsed once and can be executed multiple times with different parameters, avoiding repeated parsing overhead.
+
+```pony
+// Prepare a named statement
+session.prepare("find_user", "SELECT * FROM users WHERE id = $1", receiver)
+
+// In the PrepareReceiver callback:
+be pg_statement_prepared(name: String) =>
+  // Execute with different parameters
+  session.execute(
+    NamedPreparedQuery("find_user",
+      recover val [as (String | None): "42"] end),
+    result_receiver)
+
+// Clean up when done
+session.close_statement("find_user")
+```
+
+The `Query` union type now includes `NamedPreparedQuery`, so exhaustive matches on `Query` need a new branch:
+
+```pony
+match query
+| let sq: SimpleQuery => sq.string
+| let pq: PreparedQuery => pq.string
+| let nq: NamedPreparedQuery => nq.name
+end
+```

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -58,7 +58,7 @@ Each `PreparedQuery` must contain a single SQL statement. For multi-statement ex
 
 ## Change ResultReceiver and Result to use Query union type
 
-`ResultReceiver.pg_query_failed` and `Result.query()` now use `Query` (a union of `SimpleQuery | PreparedQuery`) instead of `SimpleQuery`.
+`ResultReceiver.pg_query_failed` and `Result.query()` now use `Query` (a union of `SimpleQuery | PreparedQuery | NamedPreparedQuery`) instead of `SimpleQuery`.
 
 Before:
 
@@ -75,6 +75,10 @@ After:
 be pg_query_failed(query: Query,
   failure: (ErrorResponseMessage | ClientQueryError))
 =>
-  // handle failure
+  match query
+  | let sq: SimpleQuery => // ...
+  | let pq: PreparedQuery => // ...
+  | let nq: NamedPreparedQuery => // ...
+  end
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,10 @@ Minimal example using `SimpleQuery`. Connects, authenticates, executes `SELECT 5
 
 Parameterized queries using `PreparedQuery`. Sends a query with typed parameters (`text`, `int4`) and a NULL parameter, then inspects the `ResultSet`. Shows how to construct the `Array[(String | None)] val` parameter array.
 
+## named-prepared-query
+
+Named prepared statements using `Session.prepare()` and `NamedPreparedQuery`. Prepares a statement once, executes it twice with different parameters, then cleans up with `Session.close_statement()`. Shows how to implement `PrepareReceiver` for prepare lifecycle callbacks.
+
 ## crud
 
 Multi-query workflow mixing `SimpleQuery` and `PreparedQuery`. Creates a table, inserts rows with parameterized INSERTs, selects them back, deletes, and drops the table. Demonstrates all three `Result` types (`ResultSet`, `RowModifying`, `SimpleResult`) and `ErrorResponseMessage` error handling.

--- a/examples/named-prepared-query/named-prepared-query-example.pony
+++ b/examples/named-prepared-query/named-prepared-query-example.pony
@@ -1,0 +1,115 @@
+use "cli"
+use "collections"
+use lori = "lori"
+// in your code this `use` statement would be:
+// use "postgres"
+use "../../postgres"
+
+actor Main
+  new create(env: Env) =>
+    let server_info = ServerInfo(env.vars)
+    let auth = lori.TCPConnectAuth(env.root)
+
+    let client = Client(auth, server_info, env.out)
+
+actor Client is (SessionStatusNotify & ResultReceiver & PrepareReceiver)
+  let _session: Session
+  let _out: OutStream
+  var _executions_remaining: U32 = 2
+
+  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+    _out = out
+    _session = Session(
+      auth,
+      this,
+      info.host,
+      info.port,
+      info.username,
+      info.password,
+      info.database)
+
+  be close() =>
+    _session.close()
+
+  be pg_session_authenticated(session: Session) =>
+    _out.print("Authenticated.")
+    _out.print("Preparing statement 'greet'...")
+    // Prepare a named statement once; execute it multiple times later.
+    session.prepare("greet",
+      "SELECT $1::text AS greeting, $2::text AS name", this)
+
+  be pg_session_authentication_failed(
+    s: Session,
+    reason: AuthenticationFailureReason)
+  =>
+    _out.print("Failed to authenticate.")
+
+  be pg_statement_prepared(name: String) =>
+    _out.print("Statement '" + name + "' prepared.")
+    // Execute the same prepared statement with different parameters.
+    _session.execute(
+      NamedPreparedQuery("greet",
+        recover val [as (String | None): "Hello"; "Pony"] end),
+      this)
+    _session.execute(
+      NamedPreparedQuery("greet",
+        recover val [as (String | None): "Hi"; "World"] end),
+      this)
+
+  be pg_prepare_failed(name: String,
+    failure: (ErrorResponseMessage | ClientQueryError))
+  =>
+    _out.print("Failed to prepare statement '" + name + "'.")
+    close()
+
+  be pg_query_result(result: Result) =>
+    match result
+    | let r: ResultSet =>
+      _out.print("ResultSet (" + r.rows().size().string() + " rows):")
+      for row in r.rows().values() do
+        for field in row.fields.values() do
+          _out.write("  " + field.name + "=")
+          match field.value
+          | let v: String => _out.print(v)
+          | let v: I16 => _out.print(v.string())
+          | let v: I32 => _out.print(v.string())
+          | let v: I64 => _out.print(v.string())
+          | let v: F32 => _out.print(v.string())
+          | let v: F64 => _out.print(v.string())
+          | let v: Bool => _out.print(v.string())
+          | None => _out.print("NULL")
+          end
+        end
+      end
+    | let r: RowModifying =>
+      _out.print(r.command() + " " + r.impacted().string() + " rows")
+    | let r: SimpleResult =>
+      _out.print("Query executed.")
+    end
+    _executions_remaining = _executions_remaining - 1
+    if _executions_remaining == 0 then
+      _out.print("All executions complete. Closing statement...")
+      _session.close_statement("greet")
+      close()
+    end
+
+  be pg_query_failed(query: Query,
+    failure: (ErrorResponseMessage | ClientQueryError))
+  =>
+    _out.print("Query failed.")
+    close()
+
+class val ServerInfo
+  let host: String
+  let port: String
+  let username: String
+  let password: String
+  let database: String
+
+  new val create(vars: (Array[String] val | None)) =>
+    let e = EnvVars(vars)
+    host = try e("POSTGRES_HOST")? else "127.0.0.1" end
+    port = try e("POSTGRES_PORT")? else "5432" end
+    username = try e("POSTGRES_USERNAME")? else "postgres" end
+    password = try e("POSTGRES_PASSWORD")? else "postgres" end
+    database = try e("POSTGRES_DATABASE")? else "postgres" end

--- a/postgres/_frontend_message.pony
+++ b/postgres/_frontend_message.pony
@@ -237,6 +237,60 @@ primitive _FrontendMessage
       []
     end
 
+  fun describe_statement(name: String): Array[U8] val =>
+    """
+    Build a Describe message for a prepared statement.
+
+    Format: Byte1('D') Int32(len) Byte1('S') String(name)
+    """
+    try
+      recover val
+        // 1 type + 4 length + 1 indicator + name + null
+        let length: U32 = 4 + 1 + name.size().u32() + 1
+        let msg_size = (length + 1).usize()
+        let msg: Array[U8] = Array[U8].init(0, msg_size)
+        msg.update_u8(0, 'D')?
+        ifdef bigendian then
+          msg.update_u32(1, length)?
+        else
+          msg.update_u32(1, length.bswap())?
+        end
+        msg.update_u8(5, 'S')?
+        msg.copy_from(name.array(), 0, 6, name.size())
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end
+
+  fun close_statement(name: String): Array[U8] val =>
+    """
+    Build a Close message for a prepared statement.
+
+    Format: Byte1('C') Int32(len) Byte1('S') String(name)
+    """
+    try
+      recover val
+        // 1 type + 4 length + 1 indicator + name + null
+        let length: U32 = 4 + 1 + name.size().u32() + 1
+        let msg_size = (length + 1).usize()
+        let msg: Array[U8] = Array[U8].init(0, msg_size)
+        msg.update_u8(0, 'C')?
+        ifdef bigendian then
+          msg.update_u32(1, length)?
+        else
+          msg.update_u32(1, length.bswap())?
+        end
+        msg.update_u8(5, 'S')?
+        msg.copy_from(name.array(), 0, 6, name.size())
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end
+
   fun execute_msg(portal: String, max_rows: U32): Array[U8] val =>
     """
     Build an Execute message.

--- a/postgres/_test_frontend_message.pony
+++ b/postgres/_test_frontend_message.pony
@@ -153,6 +153,38 @@ class \nodoc\ iso _TestFrontendMessageExecute is UnitTest
     h.assert_array_eq[U8](expected,
       _FrontendMessage.execute_msg("", 0))
 
+class \nodoc\ iso _TestFrontendMessageDescribeStatement is UnitTest
+  fun name(): String =>
+    "FrontendMessage/DescribeStatement"
+
+  fun apply(h: TestHelper) =>
+    // DescribeStatement("s1")
+    // Length = 4 + 1 + 2+1 = 8, total = 9
+    let expected: Array[U8] = ifdef bigendian then
+      [ 68; 8; 0; 0; 0; 83; 115; 49; 0 ]
+    else
+      [ 68; 0; 0; 0; 8; 83; 115; 49; 0 ]
+    end
+
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.describe_statement("s1"))
+
+class \nodoc\ iso _TestFrontendMessageCloseStatement is UnitTest
+  fun name(): String =>
+    "FrontendMessage/CloseStatement"
+
+  fun apply(h: TestHelper) =>
+    // CloseStatement("s1")
+    // Length = 4 + 1 + 2+1 = 8, total = 9
+    let expected: Array[U8] = ifdef bigendian then
+      [ 67; 8; 0; 0; 0; 83; 115; 49; 0 ]
+    else
+      [ 67; 0; 0; 0; 8; 83; 115; 49; 0 ]
+    end
+
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.close_statement("s1"))
+
 class \nodoc\ iso _TestFrontendMessageSync is UnitTest
   fun name(): String =>
     "FrontendMessage/Sync"

--- a/postgres/named_prepared_query.pony
+++ b/postgres/named_prepared_query.pony
@@ -1,0 +1,14 @@
+class val NamedPreparedQuery
+  """
+  Executes a previously prepared server-side statement by name. The statement
+  must have been created via `Session.prepare()` before executing this query.
+
+  Parameters are referenced as $1, $2, ... in the original SQL string that was
+  passed to `prepare()`. Values are sent in text format; use None for NULL.
+  """
+  let name: String
+  let params: Array[(String | None)] val
+
+  new val create(name': String, params': Array[(String | None)] val) =>
+    name = name'
+    params = params'

--- a/postgres/prepare_receiver.pony
+++ b/postgres/prepare_receiver.pony
@@ -1,0 +1,16 @@
+interface tag PrepareReceiver
+  """
+  Receives the result of a `Session.prepare()` call.
+  """
+  be pg_statement_prepared(name: String)
+    """
+    Called when the server has successfully prepared a named statement.
+    """
+
+  be pg_prepare_failed(name: String,
+    failure: (ErrorResponseMessage | ClientQueryError))
+    """
+    Called when statement preparation fails. The failure is either a server
+    error (ErrorResponseMessage) or a client-side error (ClientQueryError)
+    such as the session being closed or not yet authenticated.
+    """

--- a/postgres/query.pony
+++ b/postgres/query.pony
@@ -1,6 +1,8 @@
-type Query is (SimpleQuery | PreparedQuery)
+type Query is (SimpleQuery | PreparedQuery | NamedPreparedQuery)
   """
   A query that can be executed via `Session.execute()`. SimpleQuery uses the
   simple query protocol (unparameterized); PreparedQuery uses the extended
-  query protocol (parameterized).
+  query protocol with an unnamed prepared statement (parameterized);
+  NamedPreparedQuery executes a previously prepared named statement with
+  parameters.
   """


### PR DESCRIPTION
Implements the design from [discussion #77](https://github.com/ponylang/postgres/discussions/77). Adds `Session.prepare()` to create server-side named statements, `Session.close_statement()` to destroy them, `NamedPreparedQuery` to execute them, and `PrepareReceiver` for prepare lifecycle callbacks.

Breaking change: the `Query` union type expands to include `NamedPreparedQuery`, requiring a new branch in exhaustive matches.