### PR TITLE
Pass session to ResultReceiver and PrepareReceiver callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ All notable changes to this project will be documented in this file. This projec
 - Add parameterized queries via extended query protocol ([PR #70](https://github.com/ponylang/postgres/pull/70))
 - Add named prepared statement support ([PR #78](https://github.com/ponylang/postgres/pull/78))
 - Add SSL/TLS negotiation support ([PR #79](https://github.com/ponylang/postgres/pull/79))
+- Enable follow-up queries from ResultReceiver and PrepareReceiver callbacks ([PR #84](https://github.com/ponylang/postgres/pull/84))
 
 ### Changed
 
 - Change ResultReceiver and Result to use Query union type instead of SimpleQuery ([PR #70](https://github.com/ponylang/postgres/pull/70))
+- Change ResultReceiver and PrepareReceiver callbacks to take Session as first parameter ([PR #84](https://github.com/ponylang/postgres/pull/84))
 - Fix typo in SesssionNeverOpened ([PR #59](https://github.com/ponylang/postgres/pull/59))
 
 ## [0.2.2] - 2025-07-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ Only one operation is in-flight at a time. The queue serializes execution. `quer
 - `Rows` / `Row` / `Field` — result data. `Field.value` is `FieldDataTypes` union
 - `FieldDataTypes` = `(Bool | F32 | F64 | I16 | I32 | I64 | None | String)`
 - `SessionStatusNotify` interface (tag) — lifecycle callbacks (connected, connection_failed, authenticated, authentication_failed, shutdown)
-- `ResultReceiver` interface (tag) — `pg_query_result(Result)`, `pg_query_failed(Query, (ErrorResponseMessage | ClientQueryError))`
-- `PrepareReceiver` interface (tag) — `pg_statement_prepared(name)`, `pg_prepare_failed(name, (ErrorResponseMessage | ClientQueryError))`
+- `ResultReceiver` interface (tag) — `pg_query_result(Session, Result)`, `pg_query_failed(Session, Query, (ErrorResponseMessage | ClientQueryError))`
+- `PrepareReceiver` interface (tag) — `pg_statement_prepared(Session, name)`, `pg_prepare_failed(Session, name, (ErrorResponseMessage | ClientQueryError))`
 - `ClientQueryError` trait — `SessionNeverOpened`, `SessionClosed`, `SessionNotAuthenticated`, `DataError`
 - `SSLMode` — union type `(SSLDisabled | SSLRequired)`. `SSLDisabled` is the default (plaintext). `SSLRequired` wraps an `SSLContext val` for TLS negotiation.
 - `ErrorResponseMessage` — full PostgreSQL error with all standard fields
@@ -147,7 +147,6 @@ Test helpers: `_ConnectionTestConfiguration` reads env vars with defaults. Sever
 
 - `rows.pony:43` — TODO: need tests for Rows/Row/Field (requires implementing `eq`)
 - `_test_response_parser.pony:6` — TODO: chain-of-messages tests to verify correct buffer advancement across message sequences
-- `result_receiver.pony:1` — TODO: consider passing session to result callbacks so receivers without a session tag can execute follow-up queries
 
 ## Roadmap
 

--- a/examples/crud/crud-example.pony
+++ b/examples/crud/crud-example.pony
@@ -49,7 +49,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   =>
     _out.print("Failed to authenticate.")
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
     match _phase
@@ -135,7 +135,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
       _out.print(r.command() + " " + r.impacted().string() + " rows")
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     match failure

--- a/examples/named-prepared-query/named-prepared-query-example.pony
+++ b/examples/named-prepared-query/named-prepared-query-example.pony
@@ -44,7 +44,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & PrepareReceiver)
   =>
     _out.print("Failed to authenticate.")
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _out.print("Statement '" + name + "' prepared.")
     // Execute the same prepared statement with different parameters.
     _session.execute(
@@ -56,13 +56,13 @@ actor Client is (SessionStatusNotify & ResultReceiver & PrepareReceiver)
         recover val [as (String | None): "Hi"; "World"] end),
       this)
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _out.print("Failed to prepare statement '" + name + "'.")
     close()
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
@@ -93,7 +93,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & PrepareReceiver)
       close()
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _out.print("Query failed.")

--- a/examples/prepared-query/prepared-query-example.pony
+++ b/examples/prepared-query/prepared-query-example.pony
@@ -47,7 +47,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   =>
     _out.print("Failed to authenticate.")
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
@@ -73,7 +73,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     end
     close()
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _out.print("Query failed.")

--- a/examples/query/query-example.pony
+++ b/examples/query/query-example.pony
@@ -42,7 +42,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   =>
     _out.print("Failed to authenticate.")
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
@@ -68,7 +68,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     end
     close()
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _out.print("Query failed.")

--- a/examples/ssl-query/ssl-query-example.pony
+++ b/examples/ssl-query/ssl-query-example.pony
@@ -67,7 +67,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   =>
     _out.print("Failed to authenticate.")
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
@@ -93,7 +93,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     end
     close()
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _out.print("Query failed.")

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -380,11 +380,11 @@ actor \nodoc\ _DoesntAnswerClient is (SessionStatusNotify & ResultReceiver)
     _h.fail("Unable to authenticate.")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.fail("Unexpectedly got a result for a query.")
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     if _in_flight_queries.contains(query) then
@@ -527,7 +527,7 @@ actor \nodoc\ _ZeroRowSelectTestClient is (SessionStatusNotify & ResultReceiver)
     _h.fail("Unable to authenticate.")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     if result.query() isnt _query then
       _h.fail("Query in result isn't the expected query.")
       _close_and_complete(false)
@@ -554,7 +554,7 @@ actor \nodoc\ _ZeroRowSelectTestClient is (SessionStatusNotify & ResultReceiver)
 
     _close_and_complete(true)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure.")
@@ -692,11 +692,11 @@ actor \nodoc\ _PrepareShutdownTestClient is
     _h.fail("Unable to authenticate.")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _h.fail("Unexpectedly got a prepared statement.")
     _h.complete(false)
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     match failure

--- a/postgres/_test_query.pony
+++ b/postgres/_test_query.pony
@@ -42,7 +42,7 @@ actor \nodoc\ _ResultsIncludeOriginatingQueryReceiver is
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     if result.query() isnt _query then
       _h.fail("Query in result isn't the expected query.")
       _h.complete(false)
@@ -83,7 +83,7 @@ actor \nodoc\ _ResultsIncludeOriginatingQueryReceiver is
 
     _h.complete(true)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure")
@@ -131,11 +131,11 @@ actor \nodoc\ _QueryAfterAuthenticationFailureNotify is
   =>
     session.execute(_query, this)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.fail("Unexpected query result received")
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     if (query is _query) and (failure is SessionClosed) then
@@ -185,11 +185,11 @@ actor \nodoc\ _QueryAfterConnectionFailureNotify is
   be pg_session_connection_failed(session: Session) =>
     session.execute(_query, this)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.fail("Unexpected query result received")
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     if (query is _query) and (failure is SessionClosed) then
@@ -242,11 +242,11 @@ actor \nodoc\ _QueryAfterSessionHasBeenClosedNotify is
   be pg_session_shutdown(session: Session) =>
     session.execute(_query, this)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.fail("Unexpected query result received")
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     if (query is _query) and (failure is SessionClosed) then
@@ -296,11 +296,11 @@ actor \nodoc\ _NonExistentTableQueryReceiver is
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.fail("Query unexpectedly succeeded.")
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     // TODO enhance this by checking the failure
@@ -413,7 +413,7 @@ actor \nodoc\ _AllSuccessQueryRunningClient is
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     try
       let q = _queries.shift()?
       if result.query() is q then
@@ -428,7 +428,7 @@ actor \nodoc\ _AllSuccessQueryRunningClient is
       _h.complete(false)
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     let query_str = match query
@@ -483,7 +483,7 @@ actor \nodoc\ _EmptyQueryReceiver is
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     if result.query() isnt _query then
       _h.fail("Query in result isn't the expected query.")
       _h.complete(false)
@@ -492,7 +492,7 @@ actor \nodoc\ _EmptyQueryReceiver is
 
     _h.complete(true)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure")
@@ -543,7 +543,7 @@ actor \nodoc\ _ZeroRowSelectReceiver is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     if result.query() isnt _query then
       _h.fail("Query in result isn't the expected query.")
       _h.complete(false)
@@ -565,7 +565,7 @@ actor \nodoc\ _ZeroRowSelectReceiver is
 
     _h.complete(true)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure")
@@ -623,7 +623,7 @@ actor \nodoc\ _MultiStatementMixedClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
     match _phase
@@ -676,7 +676,7 @@ actor \nodoc\ _MultiStatementMixedClient is
       _drop_and_finish()
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure at phase " + _phase.string())
@@ -735,7 +735,7 @@ actor \nodoc\ _PreparedQueryResultsReceiver is
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     if result.query() isnt _query then
       _h.fail("Query in result isn't the expected query.")
       _h.complete(false)
@@ -776,7 +776,7 @@ actor \nodoc\ _PreparedQueryResultsReceiver is
 
     _h.complete(true)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure")
@@ -828,7 +828,7 @@ actor \nodoc\ _PreparedQueryNullParamReceiver is
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     if result.query() isnt _query then
       _h.fail("Query in result isn't the expected query.")
       _h.complete(false)
@@ -864,7 +864,7 @@ actor \nodoc\ _PreparedQueryNullParamReceiver is
 
     _h.complete(true)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure")
@@ -917,11 +917,11 @@ actor \nodoc\ _PreparedQueryNonExistentTableReceiver is
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.fail("Query unexpectedly succeeded.")
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     if query is _query then
@@ -985,7 +985,7 @@ actor \nodoc\ _PreparedQueryInsertAndDeleteClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
     match _phase
@@ -1041,7 +1041,7 @@ actor \nodoc\ _PreparedQueryInsertAndDeleteClient is
       _drop_and_finish()
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure at phase " + _phase.string())
@@ -1103,7 +1103,7 @@ actor \nodoc\ _PreparedQueryMixedClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
     match _phase
@@ -1172,7 +1172,7 @@ actor \nodoc\ _PreparedQueryMixedClient is
       _h.complete(false)
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure at phase " + _phase.string())
@@ -1224,7 +1224,7 @@ actor \nodoc\ _PrepareStatementClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     if name == "s1" then
       _h.complete(true)
     else
@@ -1232,7 +1232,7 @@ actor \nodoc\ _PrepareStatementClient is
       _h.complete(false)
     end
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected prepare failure")
@@ -1284,19 +1284,19 @@ actor \nodoc\ _PrepareAndExecuteClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _session.execute(
       NamedPreparedQuery("s1",
         recover val [as (String | None): "525600"] end),
       this)
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected prepare failure")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     match result
     | let r: ResultSet =>
       try
@@ -1318,7 +1318,7 @@ actor \nodoc\ _PrepareAndExecuteClient is
     end
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure")
@@ -1370,7 +1370,7 @@ actor \nodoc\ _PrepareAndExecuteMultipleClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _session.execute(
       NamedPreparedQuery("s1",
         recover val [as (String | None): "first"] end),
@@ -1380,13 +1380,13 @@ actor \nodoc\ _PrepareAndExecuteMultipleClient is
         recover val [as (String | None): "second"] end),
       this)
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected prepare failure")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
     match result
@@ -1426,7 +1426,7 @@ actor \nodoc\ _PrepareAndExecuteMultipleClient is
       return
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure at phase " + _phase.string())
@@ -1478,24 +1478,24 @@ actor \nodoc\ _PrepareAndCloseClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _session.close_statement("s1")
     _session.execute(
       NamedPreparedQuery("s1",
         recover val [as (String | None): "hello"] end),
       this)
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected prepare failure")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.fail("Expected query failure after closing statement.")
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     match failure
@@ -1551,11 +1551,11 @@ actor \nodoc\ _PrepareFailsClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _h.fail("Expected prepare to fail but it succeeded.")
     _h.complete(false)
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     if name != "bad" then
@@ -1618,7 +1618,7 @@ actor \nodoc\ _PrepareAfterCloseClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _phase = _phase + 1
 
     match _phase
@@ -1634,13 +1634,13 @@ actor \nodoc\ _PrepareAfterCloseClient is
       _h.complete(false)
     end
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected prepare failure at phase " + _phase.string())
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     match result
     | let r: ResultSet =>
       try
@@ -1662,7 +1662,7 @@ actor \nodoc\ _PrepareAfterCloseClient is
     end
     _h.complete(false)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure")
@@ -1716,10 +1716,10 @@ actor \nodoc\ _CloseNonexistentClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _h.complete(true)
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure after closing nonexistent statement.")
@@ -1773,7 +1773,7 @@ actor \nodoc\ _PrepareDuplicateNameClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _phase = _phase + 1
     if _phase == 1 then
       _session.prepare("dup", "SELECT 2", this)
@@ -1782,7 +1782,7 @@ actor \nodoc\ _PrepareDuplicateNameClient is
       _h.complete(false)
     end
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _phase = _phase + 1
@@ -1846,20 +1846,20 @@ actor \nodoc\ _MixedAllThreeClient is
     _h.fail("Unable to authenticate")
     _h.complete(false)
 
-  be pg_statement_prepared(name: String) =>
+  be pg_statement_prepared(session: Session, name: String) =>
     _phase = _phase + 1
     _session.execute(
       NamedPreparedQuery("mix",
         recover val [as (String | None): "named"] end),
       this)
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected prepare failure at phase " + _phase.string())
     _h.complete(false)
 
-  be pg_query_result(result: Result) =>
+  be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
     match result
@@ -1909,7 +1909,7 @@ actor \nodoc\ _MixedAllThreeClient is
       _h.complete(false)
     end
 
-  be pg_query_failed(query: Query,
+  be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
     _h.fail("Unexpected query failure at phase " + _phase.string())

--- a/postgres/prepare_receiver.pony
+++ b/postgres/prepare_receiver.pony
@@ -1,13 +1,16 @@
 interface tag PrepareReceiver
   """
-  Receives the result of a `Session.prepare()` call.
+  Receives the result of a `Session.prepare()` call. The session is passed to
+  each callback so receivers can execute follow-up operations (such as
+  executing the prepared statement) without needing to store a session
+  reference.
   """
-  be pg_statement_prepared(name: String)
+  be pg_statement_prepared(session: Session, name: String)
     """
     Called when the server has successfully prepared a named statement.
     """
 
-  be pg_prepare_failed(name: String,
+  be pg_prepare_failed(session: Session, name: String,
     failure: (ErrorResponseMessage | ClientQueryError))
     """
     Called when statement preparation fails. The failure is either a server

--- a/postgres/result_receiver.pony
+++ b/postgres/result_receiver.pony
@@ -1,12 +1,18 @@
-// TODO SEAN: consider if each of these should take the session as well. If yes,
-// it means that on success or failure, an actor that knows nothing about the
-// session (ie no tag) could use it to execute additional commands after getting
-// results. There are pros and cons to that.
 interface tag ResultReceiver
-  be pg_query_result(result: Result)
+  """
+  Receives the result of a `Session.execute()` call. The session is passed to
+  each callback so receivers can execute follow-up queries without needing to
+  store a session reference.
+  """
+  be pg_query_result(session: Session, result: Result)
     """
+    Called when a query completes successfully.
     """
 
-  be pg_query_failed(query: Query, failure: (ErrorResponseMessage | ClientQueryError))
+  be pg_query_failed(session: Session, query: Query,
+    failure: (ErrorResponseMessage | ClientQueryError))
     """
+    Called when a query fails. The failure is either a server error
+    (ErrorResponseMessage) or a client-side error (ClientQueryError) such as
+    the session being closed or never opened.
     """


### PR DESCRIPTION
Adds `session: Session` as the first parameter to all `ResultReceiver` and `PrepareReceiver` callbacks, matching the convention already used by `SessionStatusNotify`. This is a breaking API change that enables receivers to execute follow-up queries, close the session, or perform other session operations directly from the callback without needing to store a session reference at construction time.

Resolves the TODO in result_receiver.pony.

Design: #72