### PR TITLE
Send Terminate message before closing TCP connection

### DIFF
--- a/.release-notes/graceful-termination.md
+++ b/.release-notes/graceful-termination.md
@@ -1,0 +1,5 @@
+## Send Terminate message before closing TCP connection
+
+`Session.close()` now sends a Terminate message to the PostgreSQL server before closing the TCP connection. Previously, the connection was hard-closed without notifying the server, which could leave server-side resources (session state, prepared statements, temp tables) lingering until the server detected the broken connection on its next I/O attempt.
+
+No code changes are needed — `Session.close()` handles this automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Only one operation is in-flight at a time. The queue serializes execution. `quer
 ### Protocol Layer
 
 **Frontend (client → server):**
-- `_FrontendMessage` primitive: `startup()`, `password()`, `query()`, `parse()`, `bind()`, `describe_portal()`, `describe_statement()`, `execute_msg()`, `close_statement()`, `sync()`, `ssl_request()` — builds raw byte arrays with big-endian wire format
+- `_FrontendMessage` primitive: `startup()`, `password()`, `query()`, `parse()`, `bind()`, `describe_portal()`, `describe_statement()`, `execute_msg()`, `close_statement()`, `sync()`, `ssl_request()`, `terminate()` — builds raw byte arrays with big-endian wire format
 
 **Backend (server → client):**
 - `_ResponseParser` primitive: incremental parser consuming from a `Reader` buffer. Returns one parsed message per call, `None` if incomplete, errors on junk.
@@ -125,6 +125,7 @@ Tests live in the main `postgres/` package (private test classes).
 - `_TestHandlingJunkMessages` — uses a local TCP listener that sends junk; verifies session shuts down
 - `_TestUnansweredQueriesFailOnShutdown` — uses a local TCP listener that auto-auths but never responds to queries; verifies queued queries get `SessionClosed` failures
 - `_TestPrepareShutdownDrainsPrepareQueue` — uses a local TCP listener that auto-auths but never becomes ready; verifies pending prepare operations get `SessionClosed` failures on shutdown
+- `_TestTerminateSentOnClose` — mock server fully authenticates and becomes ready; verifies that closing the session sends a Terminate message ('X') to the server
 - `_TestSSLNegotiationRefused` — mock server responds 'N' to SSLRequest; verifies `pg_session_connection_failed` fires
 - `_TestSSLNegotiationJunkResponse` — mock server responds with junk byte to SSLRequest; verifies session shuts down
 - `_TestSSLNegotiationSuccess` — mock server responds 'S', both sides upgrade to TLS, sends AuthOk+ReadyForQuery; verifies full SSL→auth flow

--- a/postgres/_frontend_message.pony
+++ b/postgres/_frontend_message.pony
@@ -368,3 +368,26 @@ primitive _FrontendMessage
       _Unreachable()
       []
     end
+
+  fun terminate(): Array[U8] val =>
+    """
+    Build a Terminate message. Sent before closing the TCP connection to
+    notify the server of an orderly shutdown.
+
+    Format: Byte1('X') Int32(4)
+    """
+    try
+      recover val
+        let msg: Array[U8] = Array[U8].init(0, 5)
+        msg.update_u8(0, 'X')?
+        ifdef bigendian then
+          msg.update_u32(1, U32(4))?
+        else
+          msg.update_u32(1, U32(4).bswap())?
+        end
+        msg
+      end
+    else
+      _Unreachable()
+      []
+    end

--- a/postgres/_test_frontend_message.pony
+++ b/postgres/_test_frontend_message.pony
@@ -214,3 +214,18 @@ class \nodoc\ iso _TestFrontendMessageSSLRequest is UnitTest
 
     h.assert_array_eq[U8](expected,
       _FrontendMessage.ssl_request())
+
+class \nodoc\ iso _TestFrontendMessageTerminate is UnitTest
+  fun name(): String =>
+    "FrontendMessage/Terminate"
+
+  fun apply(h: TestHelper) =>
+    // Terminate: Byte1('X') Int32(4) = 5 bytes
+    let expected: Array[U8] = ifdef bigendian then
+      [ 'X'; 4; 0; 0; 0 ]
+    else
+      [ 'X'; 0; 0; 0; 4 ]
+    end
+
+    h.assert_array_eq[U8](expected,
+      _FrontendMessage.terminate())

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -49,8 +49,9 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
 
   be close() =>
     """
-    Hard closes the connection. Terminates as soon as possible without waiting
-    for outstanding queries to finish.
+    Close the connection. Sends a Terminate message to the server before
+    closing the TCP connection. Does not wait for outstanding queries to
+    finish.
     """
     state.close(this)
 
@@ -1078,6 +1079,7 @@ trait _ConnectedState is _NotConnectableState
 
   fun ref shutdown(s: Session ref) =>
     on_shutdown(s)
+    s._connection().send(_FrontendMessage.terminate())
     s._connection().close()
     notify().pg_session_shutdown(s)
     s.state = _SessionClosed


### PR DESCRIPTION
`Session.close()` now sends a Terminate (`X`) message to the PostgreSQL server before closing the TCP connection. Previously, the connection was hard-closed without notifying the server, leaving server-side resources to linger until the server detected the broken connection.

The Terminate is sent from `_ConnectedState.shutdown()`, covering both authentication and query phases. `_SessionSSLNegotiating` correctly skips it since the PostgreSQL protocol hasn't started during SSL negotiation. The send is best-effort — if the connection is already broken, it silently fails and close proceeds normally.

Design: #72