### PR TITLE
Add SSL service container to nightly CI workflow

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -29,6 +29,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      postgres-ssl:
+        image: ghcr.io/ponylang/postgres-ci-pg-ssl:latest
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: md5
+          POSTGRES_INITDB_ARGS: "--auth-host=md5"
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
@@ -39,6 +52,8 @@ jobs:
         env:
           POSTGRES_HOST: postgres
           POSTGRES_PORT: 5432
+          POSTGRES_SSL_HOST: postgres-ssl
+          POSTGRES_SSL_PORT: 5432
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DATABASE: postgres


### PR DESCRIPTION
The `postgres-ssl` service container and `POSTGRES_SSL_HOST`/`POSTGRES_SSL_PORT` env vars were added to `pr.yml` when SSL testing was introduced but missed in `breakage-against-ponyc-latest.yml`. Without them, the nightly workflow's SSL integration tests fail because there's no SSL-enabled PostgreSQL instance to connect to.