### PR TITLE
Fix stale docstring on _TestSSLAuthenticate

### DIFF
--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -1242,7 +1242,7 @@ class \nodoc\ iso _TestSSLConnect is UnitTest
 class \nodoc\ iso _TestSSLAuthenticate is UnitTest
   """
   Verifies that connecting with SSLRequired to a PostgreSQL server with SSL
-  enabled allows successful MD5 authentication over the encrypted connection.
+  enabled allows successful authentication over the encrypted connection.
   """
   fun name(): String =>
     "integration/SSL/Authenticate"


### PR DESCRIPTION
The SCRAM-SHA-256 PR (#94) changed the CI container's default auth from MD5 to SCRAM-SHA-256, making the docstring's "MD5 authentication" claim inaccurate. The test doesn't assert which auth method is used, so just say "authentication".