### PR TITLE
Fix unsupported authentication type causing silent hang

### DIFF
--- a/.release-notes/fix-unsupported-auth-hang.md
+++ b/.release-notes/fix-unsupported-auth-hang.md
@@ -1,0 +1,3 @@
+## Fix unsupported authentication type causing silent hang
+
+When a PostgreSQL server requested an authentication method the driver doesn't support (e.g., cleartext password, Kerberos, GSSAPI), the session would hang indefinitely with no error reported. It now correctly fails with `UnsupportedAuthenticationMethod` via the `pg_session_authentication_failed` callback.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ Tests live in the main `postgres/` package (private test classes).
 - `_TestSCRAMUnsupportedMechanism` — mock server offers only unsupported SASL mechanisms; verifies `pg_session_authentication_failed` with `UnsupportedAuthenticationMethod`
 - `_TestSCRAMServerVerificationFailed` — mock server sends wrong signature in SASLFinal; verifies `pg_session_authentication_failed` with `ServerVerificationFailed`
 - `_TestSCRAMErrorDuringAuth` — mock server sends ErrorResponse 28P01 during SCRAM exchange; verifies `pg_session_authentication_failed` with `InvalidPassword`
+- `_TestUnsupportedAuthentication` — mock server sends unsupported auth type (cleartext password); verifies `pg_session_authentication_failed` with `UnsupportedAuthenticationMethod`
 - `_TestField*Equality*` / `_TestFieldInequality` — example-based reflexive, structural, symmetric equality and inequality tests for Field
 - `_TestRowEquality` / `_TestRowInequality` — example-based equality and inequality tests for Row
 - `_TestRowsEquality` / `_TestRowsInequality` — example-based equality and inequality tests for Rows

--- a/postgres/_backend_messages.pony
+++ b/postgres/_backend_messages.pony
@@ -45,6 +45,12 @@ class val _AuthenticationSASLFinalMessage
   new val create(data': Array[U8] val) =>
     data = data'
 
+primitive _UnsupportedAuthenticationMessage
+  """
+  Message indicating the server requested an authentication method that this
+  driver does not support (e.g., cleartext password, Kerberos, GSSAPI).
+  """
+
 class val _BackendKeyDataMessage
   """
   Message from the backend containing the process ID and secret key for this

--- a/postgres/_response_message_parser.pony
+++ b/postgres/_response_message_parser.pony
@@ -24,6 +24,9 @@ primitive _ResponseMessageParser
           s.state.on_authentication_sasl_continue(s, msg)
         | let msg: _AuthenticationSASLFinalMessage =>
           s.state.on_authentication_sasl_final(s, msg)
+        | _UnsupportedAuthenticationMessage =>
+          s.state.on_authentication_failed(s, UnsupportedAuthenticationMethod)
+          return
         | let msg: _CommandCompleteMessage =>
           s.state.on_command_complete(s, msg)
         | let msg: _DataRowMessage =>

--- a/postgres/_response_parser.pony
+++ b/postgres/_response_parser.pony
@@ -6,7 +6,8 @@ type _AuthenticationMessages is
   | _AuthenticationMD5PasswordMessage
   | _AuthenticationSASLMessage
   | _AuthenticationSASLContinueMessage
-  | _AuthenticationSASLFinalMessage )
+  | _AuthenticationSASLFinalMessage
+  | _UnsupportedAuthenticationMessage )
 
 type _ResponseParserResult is
   ( _AuthenticationMessages
@@ -120,7 +121,7 @@ primitive _ResponseParser
         return _AuthenticationSASLFinalMessage(consume data)
       else
         buffer.skip(message_size)?
-        return _UnsupportedMessage
+        return _UnsupportedAuthenticationMessage
       end
     | _MessageType.error_response() =>
       // Slide past the header...

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -754,6 +754,24 @@ class \nodoc\ iso _TestResponseParserAuthenticationSASLFinalMessage
       h.fail("Wrong message returned.")
     end
 
+class \nodoc\ iso _TestResponseParserUnsupportedAuthenticationMessage
+  is UnitTest
+  """
+  Verify that an authentication request with an unsupported type (e.g.,
+  cleartext password, type 3) is parsed as _UnsupportedAuthenticationMessage.
+  """
+  fun name(): String =>
+    "ResponseParser/UnsupportedAuthenticationMessage"
+
+  fun apply(h: TestHelper) ? =>
+    let bytes = _IncomingUnsupportedAuthenticationTestMessage(3).bytes()
+    let r: Reader = Reader
+    r.append(bytes)
+
+    if _ResponseParser(r)? isnt _UnsupportedAuthenticationMessage then
+      h.fail("Wrong message returned.")
+    end
+
 class \nodoc\ iso _TestResponseParserMultipleMessagesSASLFirst is UnitTest
   """
   Verify correct buffer advancement from an AuthenticationSASL message
@@ -834,6 +852,26 @@ class \nodoc\ val _IncomingAuthenticationSASLFinalTestMessage
     wb.u32_be(payload_size)
     wb.i32_be(_AuthenticationRequestType.sasl_final())
     wb.write(data)
+
+    _bytes = WriterToByteArray(wb)
+
+  fun bytes(): Array[U8] val =>
+    _bytes
+
+class \nodoc\ val _IncomingUnsupportedAuthenticationTestMessage
+  """
+  Constructs a raw authentication request message with an unsupported auth
+  type. The wire format is the same as AuthenticationOk (8-byte payload with
+  just the auth type field), since unsupported types have no additional data
+  the driver needs to parse.
+  """
+  let _bytes: Array[U8] val
+
+  new val create(auth_type: I32) =>
+    let wb: Writer = Writer
+    wb.u8(_MessageType.authentication_request())
+    wb.u32_be(8)
+    wb.i32_be(auth_type)
 
     _bytes = WriterToByteArray(wb)
 


### PR DESCRIPTION
When a PostgreSQL server requests an authentication method the driver doesn't support (e.g., cleartext password, Kerberos, GSSAPI), the session hung indefinitely with no error reported. The root cause: `_UnsupportedMessage` served double duty — returned for both unknown auth types (should fail explicitly) and unknown message type bytes (should silently skip ParameterStatus, NoticeResponse, etc.). Since `_ResponseMessageParser` had no match arm for it, unsupported auth types were silently consumed.

This introduces `_UnsupportedAuthenticationMessage` to distinguish the two cases. The dispatcher routes it to `on_authentication_failed` with `UnsupportedAuthenticationMethod` (already in the public API from PR #94, but previously only reachable via the SCRAM-specific mechanism check).

Closes #93