### PR TITLE
Update lori dependency from 0.7.2 to 0.8.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 2.0.0 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.7.2 (TCP networking, STARTTLS support)
+- `ponylang/lori` 0.8.1 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
    {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.7.2"
+      "version": "0.8.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
lori 0.8.0 had a regression (ponylang/lori#183) where `_on_connection_failure()` fired spuriously after `hard_close()` on an already-connected session, crashing the `TerminateSentOnClose` test. lori 0.8.1 fixes this. Skipping 0.8.0 entirely.

All 80 unit tests and 37 integration tests pass. Examples build cleanly.