### PR TITLE
Fix mock server TCP segment splitting vulnerability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,8 @@ Tests live in the main `postgres/` package (private test classes), organized acr
 
 **`_test_scram.pony`** — SCRAM-SHA-256 computation unit tests (`_TestScramSha256MessageBuilders`, `_TestScramSha256ComputeProof`).
 
+**`_test_mock_message_reader.pony`** — `_MockMessageReader` class that buffers TCP data and extracts complete PostgreSQL frontend messages. Two methods: `read_startup_message()` for startup-format messages (Int32 length + payload — StartupMessage, SSLRequest, CancelRequest) and `read_message()` for standard-format messages (Byte1 type + Int32 length + payload). Both return `(Array[U8] val | None)`. Used by all mock servers that inspect incoming data to ensure state transitions happen on message boundaries, not TCP segment boundaries.
+
 Test helpers: `_ConnectionTestConfiguration` reads env vars with defaults. Several test message builder classes (`_Incoming*TestMessage`) construct raw protocol bytes for unit tests. Mock server tests use ports in the 7669–7691 range and 9667–9668. **Port 7680 is reserved by Windows** (Update Delivery Optimization) and will fail to bind on WSL2 — do not use it.
 
 ## Known Issues and TODOs in Code
@@ -388,6 +390,7 @@ postgres/                         # Main package (46 files)
   _test_auth.pony                 # Authentication protocol unit tests (SCRAM, unsupported auth)
   _test_md5.pony                  # MD5 integration tests
   _test_query.pony                # Query integration tests
+  _test_mock_message_reader.pony  # _MockMessageReader: TCP buffering for mock servers
   _test_response_parser.pony      # Parser unit tests + test message builders
   _test_frontend_message.pony     # Frontend message unit tests
   _test_equality.pony             # Equality tests for Field/Row/Rows (example + PonyCheck property)

--- a/postgres/_test_mock_message_reader.pony
+++ b/postgres/_test_mock_message_reader.pony
@@ -1,0 +1,56 @@
+use "buffered"
+
+class \nodoc\ _MockMessageReader
+  """
+  Buffers TCP data and extracts complete PostgreSQL frontend messages.
+
+  `_on_received` fires per TCP segment, not per protocol message. A single
+  message can split across segments, or multiple messages can arrive in one
+  segment. This class buffers incoming data and provides methods to extract
+  complete messages by parsing their length headers.
+
+  Two PostgreSQL frontend message formats are supported:
+
+  - Startup format (StartupMessage, SSLRequest, CancelRequest):
+    `Int32(length) payload` — length includes itself.
+  - Standard format (Query, Parse, SASLInitialResponse, etc.):
+    `Byte1(type) Int32(length) payload` — length includes itself but not
+    the type byte.
+
+  The caller decides which format to expect based on its own protocol state.
+  Both read methods return the complete message bytes (consuming them from
+  the buffer) or `None` if insufficient data is buffered (buffer unchanged).
+  """
+  let _readbuf: Reader = _readbuf.create()
+
+  fun ref append(data: Array[U8] val) =>
+    _readbuf.append(data)
+
+  fun ref read_startup_message(): (Array[U8] val | None) =>
+    """
+    Try to read a startup-format message. Returns the complete message
+    including the 4-byte length prefix, or None if incomplete.
+    """
+    try
+      if _readbuf.size() < 4 then return None end
+      let len = _readbuf.peek_u32_be(0)?.usize()
+      if _readbuf.size() < len then return None end
+      _readbuf.block(len)?
+    else
+      None
+    end
+
+  fun ref read_message(): (Array[U8] val | None) =>
+    """
+    Try to read a standard-format message. Returns the complete message
+    starting with the type byte, or None if incomplete.
+    """
+    try
+      if _readbuf.size() < 5 then return None end
+      let len = _readbuf.peek_u32_be(1)?.usize()
+      let total = 1 + len
+      if _readbuf.size() < total then return None end
+      _readbuf.block(total)?
+    else
+      None
+    end


### PR DESCRIPTION
Mock servers used `_received_count` or boolean flags with direct data inspection to determine protocol phase, but `_on_received` fires per TCP segment, not per protocol message. If a message split across segments, the server would respond in the wrong phase — causing intermittent test failures like the observed CopyIn/Abort flake.

Introduces `_MockMessageReader` that buffers TCP data and extracts complete PostgreSQL frontend messages before processing. Two methods handle the two wire formats: `read_startup_message()` for startup-format messages (StartupMessage, SSLRequest, CancelRequest) and `read_message()` for standard-format messages (Query, SASLInitialResponse, CopyData, etc.).

All 13 mock servers that inspect incoming data are converted to the buffered reader pattern. Six stateless/fire-and-forget servers are unchanged.

Closes #111