### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/examples/bytea/bytea-example.pony
+++ b/examples/bytea/bytea-example.pony
@@ -46,13 +46,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match field.value
+          match \exhaustive\ field.value
           | let v: Array[U8] val =>
             _out.print(v.size().string() + " bytes")
             // Print each byte's decimal value

--- a/examples/cancel/cancel-example.pony
+++ b/examples/cancel/cancel-example.pony
@@ -48,7 +48,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let err: ErrorResponseMessage =>
       if err.code == "57014" then
         _out.print("Query was cancelled (SQLSTATE 57014).")

--- a/examples/copy-in/copy-in-example.pony
+++ b/examples/copy-in/copy-in-example.pony
@@ -73,7 +73,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
   be pg_copy_failed(session: Session,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("COPY failed: [" + e.severity + "] " + e.code + ": "
         + e.message)
@@ -85,7 +85,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table dropped (or didn't exist). Create it.
       _out.print("Creating table...")
@@ -105,14 +105,14 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
         "COPY copy_in_example (name, value) FROM STDIN", this)
     | 3 =>
       // SELECT done. Print results and drop table.
-      match result
+      match \exhaustive\ result
       | let r: ResultSet =>
         _out.print("ResultSet (" + r.rows().size().string() + " rows):")
         for row in r.rows().values() do
           _out.write(" ")
           for field in row.fields.values() do
             _out.write(" " + field.name + "=")
-            match field.value
+            match \exhaustive\ field.value
             | let v: String => _out.write(v)
             | let v: I32 => _out.write(v.string())
             | None => _out.write("NULL")
@@ -133,7 +133,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/copy-out/copy-out-example.pony
+++ b/examples/copy-out/copy-out-example.pony
@@ -64,7 +64,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyOutReceiver)
   be pg_copy_failed(session: Session,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("COPY failed: [" + e.severity + "] " + e.code + ": "
         + e.message)
@@ -76,7 +76,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyOutReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table dropped (or didn't exist). Create it.
       _out.print("Creating table...")
@@ -111,7 +111,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyOutReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/crud/crud-example.pony
+++ b/examples/crud/crud-example.pony
@@ -48,7 +48,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table dropped (or didn't exist). Create it.
       _out.print("Creating table...")
@@ -89,14 +89,14 @@ actor Client is (SessionStatusNotify & ResultReceiver)
         this)
     | 5 =>
       // Select done. Print results and delete all rows.
-      match result
+      match \exhaustive\ result
       | let r: ResultSet =>
         _out.print("ResultSet (" + r.rows().size().string() + " rows):")
         for row in r.rows().values() do
           _out.write(" ")
           for field in row.fields.values() do
             _out.write(" " + field.name + "=")
-            match field.value
+            match \exhaustive\ field.value
             | let v: String => _out.write(v)
             | let v: I16 => _out.write(v.string())
             | let v: I32 => _out.write(v.string())
@@ -128,7 +128,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     end
 
   fun _print_row_modifying(result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: RowModifying =>
       _out.print(r.command() + " " + r.impacted().string() + " rows")
     end
@@ -136,7 +136,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/listen-notify/listen-notify-example.pony
+++ b/examples/listen-notify/listen-notify-example.pony
@@ -50,7 +50,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // LISTEN done, send notification
       _out.print("Subscribed. Sending notification...")
@@ -69,7 +69,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/named-prepared-query/named-prepared-query-example.pony
+++ b/examples/named-prepared-query/named-prepared-query-example.pony
@@ -59,13 +59,13 @@ actor Client is (SessionStatusNotify & ResultReceiver & PrepareReceiver)
     close()
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write("  " + field.name + "=")
-          match field.value
+          match \exhaustive\ field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/notice/notice-example.pony
+++ b/examples/notice/notice-example.pony
@@ -55,7 +55,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/parameter-status/parameter-status-example.pony
+++ b/examples/parameter-status/parameter-status-example.pony
@@ -52,7 +52,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/prepared-query/prepared-query-example.pony
+++ b/examples/prepared-query/prepared-query-example.pony
@@ -44,13 +44,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write("  " + field.name + "=")
-          match field.value
+          match \exhaustive\ field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/query/query-example.pony
+++ b/examples/query/query-example.pony
@@ -39,13 +39,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match field.value
+          match \exhaustive\ field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/ssl-preferred-query/ssl-preferred-query-example.pony
+++ b/examples/ssl-preferred-query/ssl-preferred-query-example.pony
@@ -68,13 +68,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match field.value
+          match \exhaustive\ field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/ssl-query/ssl-query-example.pony
+++ b/examples/ssl-query/ssl-query-example.pony
@@ -63,13 +63,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match field.value
+          match \exhaustive\ field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/streaming/streaming-example.pony
+++ b/examples/streaming/streaming-example.pony
@@ -86,7 +86,7 @@ actor Client is
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)
@@ -101,7 +101,7 @@ actor Client is
       _out.write("   ")
       for field in row.fields.values() do
         _out.write(" " + field.name + "=")
-        match field.value
+        match \exhaustive\ field.value
         | let v: String => _out.write(v)
         | let v: I32 => _out.write(v.string())
         | None => _out.write("NULL")
@@ -122,7 +122,7 @@ actor Client is
     query: (PreparedQuery | NamedPreparedQuery),
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Stream failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/transaction-status/transaction-status-example.pony
+++ b/examples/transaction-status/transaction-status-example.pony
@@ -41,7 +41,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_transaction_status(session: Session, status: TransactionStatus) =>
-    match status
+    match \exhaustive\ status
     | TransactionIdle => _out.print("Transaction status: idle")
     | TransactionInBlock => _out.print("Transaction status: in transaction")
     | TransactionFailed => _out.print("Transaction status: failed")
@@ -50,7 +50,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // BEGIN done. Commit to return to idle.
       _session.execute(SimpleQuery("COMMIT"), this)
@@ -63,7 +63,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/postgres/_authentication_failure_reason.pony
+++ b/postgres/_authentication_failure_reason.pony
@@ -18,7 +18,7 @@ primitive InvalidPassword
 
 primitive ServerVerificationFailed
   """
-  The server's SCRAM signature did not match the expected value. This may
+  The server's SCRAM signature did not match \exhaustive\ the expected value. This may
   indicate a man-in-the-middle attack or a misconfigured server.
   """
 

--- a/postgres/_cancel_sender.pony
+++ b/postgres/_cancel_sender.pony
@@ -32,7 +32,7 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
     _tcp_connection
 
   fun ref _on_connected() =>
-    match _info.ssl_mode
+    match \exhaustive\ _info.ssl_mode
     | SSLDisabled =>
       _send_cancel_and_close()
     | let _: (SSLRequired | SSLPreferred) =>
@@ -52,7 +52,7 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
           _tcp_connection.close()
           return
         end
-        match _tcp_connection.start_tls(ctx, _info.host)
+        match \exhaustive\ _tcp_connection.start_tls(ctx, _info.host)
         | None => None  // Handshake started, wait for _on_tls_ready
         | let _: lori.StartTLSError =>
           _tcp_connection.close()

--- a/postgres/_frontend_message.pony
+++ b/postgres/_frontend_message.pony
@@ -182,7 +182,7 @@ primitive _FrontendMessage
         end
         offset = offset + 2
         for p in params.values() do
-          match p
+          match \exhaustive\ p
           | let s: String =>
             ifdef bigendian then
               msg.update_u32(offset, s.size().u32())?

--- a/postgres/_test_cancel.pony
+++ b/postgres/_test_cancel.pony
@@ -317,7 +317,7 @@ actor \nodoc\ _SSLCancelTestServer
         // SSLRequest — respond 'S' and upgrade to TLS
         let response: Array[U8] val = ['S']
         _tcp_connection.send(response)
-        match _tcp_connection.start_tls(_sslctx)
+        match \exhaustive\ _tcp_connection.start_tls(_sslctx)
         | None => _ssl_started = true
         | let _: lori.StartTLSError =>
           _tcp_connection.close()
@@ -450,7 +450,7 @@ actor \nodoc\ _CancelPgSleepClient is
       return
     end
 
-    match failure
+    match \exhaustive\ failure
     | let err: ErrorResponseMessage =>
       if err.code == "57014" then
         _h.complete(true)

--- a/postgres/_test_copy_out.pony
+++ b/postgres/_test_copy_out.pony
@@ -776,7 +776,7 @@ actor \nodoc\ _CopyOutExportTestClient is
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _h.fail("Query failed: " + e.code + ": " + e.message)
     | let e: ClientQueryError =>

--- a/postgres/_test_equality.pony
+++ b/postgres/_test_equality.pony
@@ -5,7 +5,7 @@ use "pony_test"
 class \nodoc\ iso _TestFieldEqualityReflexive is UnitTest
   """
   Every FieldDataTypes variant produces a Field that is equal to itself.
-  Covers all 9 variants of the FieldDataTypes union to verify each match
+  Covers all 9 variants of the FieldDataTypes union to verify each match \exhaustive\
   branch in Field.eq.
   """
   fun name(): String => "Field/Equality/Reflexive"

--- a/postgres/_test_query.pony
+++ b/postgres/_test_query.pony
@@ -290,7 +290,7 @@ actor \nodoc\ _NonExistentTableQueryReceiver is
       return
     end
 
-    match failure
+    match \exhaustive\ failure
     | let e: ErrorResponseMessage =>
       _h.assert_eq[String]("42P01", e.code)
       _h.complete(true)
@@ -415,7 +415,7 @@ actor \nodoc\ _AllSuccessQueryRunningClient is
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    let query_str = match query
+    let query_str = match \exhaustive\ query
     | let sq: SimpleQuery => sq.string
     | let pq: PreparedQuery => pq.string
     | let nq: NamedPreparedQuery => nq.name
@@ -598,7 +598,7 @@ actor \nodoc\ _MultiStatementMixedClient is
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table created, now send multi-statement query
       _session.execute(
@@ -799,7 +799,7 @@ actor \nodoc\ _PreparedQueryNullParamReceiver is
       return
     end
 
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       if r.rows().size() != 1 then
         _h.fail("Wrong number of result rows.")
@@ -944,7 +944,7 @@ actor \nodoc\ _PreparedQueryInsertAndDeleteClient is
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table created, insert with PreparedQuery
       _session.execute(
@@ -1882,7 +1882,7 @@ actor \nodoc\ _CopyInInsertClient is
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table created, start COPY
       _session.copy_in(
@@ -2000,7 +2000,7 @@ actor \nodoc\ _CopyInAbortRollbackClient is
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table created, start COPY
       _session.copy_in(
@@ -2107,7 +2107,7 @@ actor \nodoc\ _ByteaQueryReceiver is
     _h.complete(false)
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       try
         let field = r.rows()(0)?.fields(0)?

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -956,7 +956,7 @@ class \nodoc\ val _IncomingDataRowTestMessage
     wb.u32_be(0)
     wb.u16_be(number_of_columns.u16())
     for column in columns.values() do
-      match column
+      match \exhaustive\ column
       | None =>
         wb.u32_be(-1)
         payload_size = payload_size + 4

--- a/postgres/_test_session.pony
+++ b/postgres/_test_session.pony
@@ -703,7 +703,7 @@ actor \nodoc\ _ByteaTestClient is (SessionStatusNotify & ResultReceiver)
     _h.complete(false)
 
   be pg_query_result(session: Session, result: Result) =>
-    match result
+    match \exhaustive\ result
     | let r: ResultSet =>
       try
         let field = r.rows()(0)?.fields(0)?

--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -341,7 +341,7 @@ actor \nodoc\ _SSLSuccessTestServer
         // Client sent SSLRequest — respond 'S' and upgrade to TLS
         let response: Array[U8] val = ['S']
         _tcp_connection.send(response)
-        match _tcp_connection.start_tls(_sslctx)
+        match \exhaustive\ _tcp_connection.start_tls(_sslctx)
         | None => _ssl_started = true
         | let _: lori.StartTLSError =>
           _tcp_connection.close()
@@ -1007,7 +1007,7 @@ actor \nodoc\ _SSLPreferredCancelTestServer
           // SSLRequest — respond 'S' and upgrade to TLS
           let response: Array[U8] val = ['S']
           _tcp_connection.send(response)
-          match _tcp_connection.start_tls(_sslctx)
+          match \exhaustive\ _tcp_connection.start_tls(_sslctx)
           | None => _ssl_started = true
           | let _: lori.StartTLSError =>
             _tcp_connection.close()

--- a/postgres/_test_transaction_status.pony
+++ b/postgres/_test_transaction_status.pony
@@ -422,7 +422,7 @@ actor \nodoc\ _TransactionCommitClient is
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match _phase
+    match \exhaustive\ _phase
     | 1 =>
       // Table created, BEGIN
       _session.execute(SimpleQuery("BEGIN"), this)

--- a/postgres/postgres.pony
+++ b/postgres/postgres.pony
@@ -131,11 +131,11 @@ Results arrive via `ResultReceiver`:
 
 ```pony
 be pg_query_result(session: Session, result: Result) =>
-  match result
+  match \exhaustive\ result
   | let rs: ResultSet =>
     for row in rs.rows().values() do
       for field in row.fields.values() do
-        match field.value
+        match \exhaustive\ field.value
         | let s: String => _env.out.print(field.name + ": " + s)
         | let i: I32 => _env.out.print(field.name + ": " + i.string())
         | let b: Bool => _env.out.print(field.name + ": " + b.string())

--- a/postgres/query_error.pony
+++ b/postgres/query_error.pony
@@ -30,6 +30,6 @@ primitive DataError is ClientQueryError
   """
   Error returned when the data that came back from a query is in a format that
   this library doesn't expect. This might indicate something like, the number
-  of columns across rows returned doesn't match or other "this should never
+  of columns across rows returned doesn't match \exhaustive\ or other "this should never
   happen" type of errors.
   """

--- a/postgres/rows.pony
+++ b/postgres/rows.pony
@@ -86,7 +86,7 @@ primitive _RowsBuilder
     Rows(consume rows)
 
   fun _field_to_type(field: (String | None), type_id: U32): FieldDataTypes ? =>
-    match field
+    match \exhaustive\ field
     | let f: String =>
       match type_id
       | 16 => f.at("t")

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -315,7 +315,7 @@ class ref _SessionSSLNegotiating
     try
       let response = data(0)?
       if response == 'S' then
-        match s._connection().start_tls(_ssl_ctx, _host)
+        match \exhaustive\ s._connection().start_tls(_ssl_ctx, _host)
         | None =>
           _handshake_started = true
         | let _: lori.StartTLSError =>
@@ -588,7 +588,7 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
         let sig_b64_iso = server_final.substring(2)
         let sig_b64: String val = consume sig_b64_iso
         let received_sig = Base64.decode[Array[U8] iso](sig_b64)?
-        match _expected_server_signature
+        match \exhaustive\ _expected_server_signature
         | let expected: Array[U8] val =>
           if not ConstantTimeCompare(expected, consume received_sig) then
             on_authentication_failed(s, ServerVerificationFailed)
@@ -844,7 +844,7 @@ class _SessionLoggedIn is _AuthenticatedState
     // double-notification, then drain the remaining queued items.
     query_state.drain_in_flight(s, this)
     for queue_item in query_queue.values() do
-      match queue_item
+      match \exhaustive\ queue_item
       | let qry: _QueuedQuery =>
         qry.receiver.pg_query_failed(s, qry.query, SessionClosed)
       | let prep: _QueuedPrepare =>
@@ -953,9 +953,9 @@ class _QueryReady is _QueryNoQueryInFlight
   fun ref try_run_query(s: Session ref, li: _SessionLoggedIn ref) =>
     try
       if li.query_queue.size() > 0 then
-        match li.query_queue(0)?
+        match \exhaustive\ li.query_queue(0)?
         | let qry: _QueuedQuery =>
-          match qry.query
+          match \exhaustive\ qry.query
           | let sq: SimpleQuery =>
             li.query_state = _SimpleQueryInFlight.create()
             s._connection().send(_FrontendMessage.query(sq.string))
@@ -1038,7 +1038,7 @@ class _QueryReady is _QueryNoQueryInFlight
           s._connection().send(_FrontendMessage.query(co.sql))
         | let sq: _QueuedStreamingQuery =>
           li.query_state = _StreamingQueryInFlight.create()
-          match sq.query
+          match \exhaustive\ sq.query
           | let pq: PreparedQuery =>
             let parse = _FrontendMessage.parse("", pq.string,
               recover val Array[U32] end)
@@ -1134,7 +1134,7 @@ class _SimpleQueryInFlight is _QueryState
         end
         let rd = _row_description = None
 
-        match rd
+        match \exhaustive\ rd
         | let desc: Array[(String, U32)] val =>
           try
             let rows_object = _RowsBuilder(consume rows, desc)?
@@ -1289,7 +1289,7 @@ class _ExtendedQueryInFlight is _QueryState
         end
         let rd = _row_description = None
 
-        match rd
+        match \exhaustive\ rd
         | let desc: Array[(String, U32)] val =>
           try
             let rows_object = _RowsBuilder(consume rows, desc)?
@@ -2206,7 +2206,7 @@ trait _ConnectableState is _UnconnectedState
   An unopened session that can be connected to a server.
   """
   fun on_connected(s: Session ref) =>
-    match ssl_mode()
+    match \exhaustive\ ssl_mode()
     | SSLDisabled =>
       s.state = _SessionConnected(notify(), database_connect_info())
       notify().pg_session_connected(s)


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.