### PR TITLE
Fix docstring corruption from exhaustive annotation

### DIFF
--- a/postgres/_authentication_failure_reason.pony
+++ b/postgres/_authentication_failure_reason.pony
@@ -18,7 +18,7 @@ primitive InvalidPassword
 
 primitive ServerVerificationFailed
   """
-  The server's SCRAM signature did not match \exhaustive\ the expected value. This may
+  The server's SCRAM signature did not match the expected value. This may
   indicate a man-in-the-middle attack or a misconfigured server.
   """
 

--- a/postgres/_test_equality.pony
+++ b/postgres/_test_equality.pony
@@ -5,7 +5,7 @@ use "pony_test"
 class \nodoc\ iso _TestFieldEqualityReflexive is UnitTest
   """
   Every FieldDataTypes variant produces a Field that is equal to itself.
-  Covers all 9 variants of the FieldDataTypes union to verify each match \exhaustive\
+  Covers all 9 variants of the FieldDataTypes union to verify each match
   branch in Field.eq.
   """
   fun name(): String => "Field/Equality/Reflexive"

--- a/postgres/postgres.pony
+++ b/postgres/postgres.pony
@@ -131,11 +131,11 @@ Results arrive via `ResultReceiver`:
 
 ```pony
 be pg_query_result(session: Session, result: Result) =>
-  match \exhaustive\ result
+  match result
   | let rs: ResultSet =>
     for row in rs.rows().values() do
       for field in row.fields.values() do
-        match \exhaustive\ field.value
+        match field.value
         | let s: String => _env.out.print(field.name + ": " + s)
         | let i: I32 => _env.out.print(field.name + ": " + i.string())
         | let b: Bool => _env.out.print(field.name + ": " + b.string())

--- a/postgres/query_error.pony
+++ b/postgres/query_error.pony
@@ -30,6 +30,6 @@ primitive DataError is ClientQueryError
   """
   Error returned when the data that came back from a query is in a format that
   this library doesn't expect. This might indicate something like, the number
-  of columns across rows returned doesn't match \exhaustive\ or other "this should never
+  of columns across rows returned doesn't match or other "this should never
   happen" type of errors.
   """


### PR DESCRIPTION
The automated `\exhaustive\` annotation script incorrectly modified "match" inside multi-line docstrings (prose text and code examples), inserting `\exhaustive\` into human-readable text and example code blocks.