### PR TITLE
Upgrade docker actions to v4

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -15,13 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
-        # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
Upgrade docker/login-action and docker/setup-buildx-action from v3 to v4.

The v3 line of both actions uses Node.js 20, which is deprecated by GitHub Actions. v4 upgrades to Node.js 24.