### PR TITLE
Build examples in PR and nightly breakage CI

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -59,6 +59,8 @@ jobs:
           POSTGRES_DATABASE: postgres
           POSTGRES_MD5_USERNAME: md5user
           POSTGRES_MD5_PASSWORD: md5pass
+      - name: Build examples
+        run: make examples config=debug ssl=libressl
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,3 +67,5 @@ jobs:
           POSTGRES_DATABASE: postgres
           POSTGRES_MD5_USERNAME: md5user
           POSTGRES_MD5_PASSWORD: md5pass
+      - name: Build examples
+        run: make examples config=debug ssl=libressl

--- a/examples/bytea/bytea-example.pony
+++ b/examples/bytea/bytea-example.pony
@@ -46,13 +46,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match \exhaustive\ result
+    match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match \exhaustive\ field.value
+          match field.value
           | let v: Array[U8] val =>
             _out.print(v.size().string() + " bytes")
             // Print each byte's decimal value

--- a/examples/cancel/cancel-example.pony
+++ b/examples/cancel/cancel-example.pony
@@ -48,7 +48,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let err: ErrorResponseMessage =>
       if err.code == "57014" then
         _out.print("Query was cancelled (SQLSTATE 57014).")

--- a/examples/copy-in/copy-in-example.pony
+++ b/examples/copy-in/copy-in-example.pony
@@ -73,7 +73,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
   be pg_copy_failed(session: Session,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("COPY failed: [" + e.severity + "] " + e.code + ": "
         + e.message)
@@ -85,7 +85,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match \exhaustive\ _phase
+    match _phase
     | 1 =>
       // Table dropped (or didn't exist). Create it.
       _out.print("Creating table...")
@@ -105,14 +105,14 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
         "COPY copy_in_example (name, value) FROM STDIN", this)
     | 3 =>
       // SELECT done. Print results and drop table.
-      match \exhaustive\ result
+      match result
       | let r: ResultSet =>
         _out.print("ResultSet (" + r.rows().size().string() + " rows):")
         for row in r.rows().values() do
           _out.write(" ")
           for field in row.fields.values() do
             _out.write(" " + field.name + "=")
-            match \exhaustive\ field.value
+            match field.value
             | let v: String => _out.write(v)
             | let v: I32 => _out.write(v.string())
             | None => _out.write("NULL")
@@ -133,7 +133,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/copy-out/copy-out-example.pony
+++ b/examples/copy-out/copy-out-example.pony
@@ -64,7 +64,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyOutReceiver)
   be pg_copy_failed(session: Session,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("COPY failed: [" + e.severity + "] " + e.code + ": "
         + e.message)
@@ -76,7 +76,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyOutReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match \exhaustive\ _phase
+    match _phase
     | 1 =>
       // Table dropped (or didn't exist). Create it.
       _out.print("Creating table...")
@@ -111,7 +111,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyOutReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/crud/crud-example.pony
+++ b/examples/crud/crud-example.pony
@@ -48,7 +48,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match \exhaustive\ _phase
+    match _phase
     | 1 =>
       // Table dropped (or didn't exist). Create it.
       _out.print("Creating table...")
@@ -89,14 +89,14 @@ actor Client is (SessionStatusNotify & ResultReceiver)
         this)
     | 5 =>
       // Select done. Print results and delete all rows.
-      match \exhaustive\ result
+      match result
       | let r: ResultSet =>
         _out.print("ResultSet (" + r.rows().size().string() + " rows):")
         for row in r.rows().values() do
           _out.write(" ")
           for field in row.fields.values() do
             _out.write(" " + field.name + "=")
-            match \exhaustive\ field.value
+            match field.value
             | let v: String => _out.write(v)
             | let v: I16 => _out.write(v.string())
             | let v: I32 => _out.write(v.string())
@@ -128,7 +128,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     end
 
   fun _print_row_modifying(result: Result) =>
-    match \exhaustive\ result
+    match result
     | let r: RowModifying =>
       _out.print(r.command() + " " + r.impacted().string() + " rows")
     end
@@ -136,7 +136,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/listen-notify/listen-notify-example.pony
+++ b/examples/listen-notify/listen-notify-example.pony
@@ -50,7 +50,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match \exhaustive\ _phase
+    match _phase
     | 1 =>
       // LISTEN done, send notification
       _out.print("Subscribed. Sending notification...")
@@ -69,7 +69,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/named-prepared-query/named-prepared-query-example.pony
+++ b/examples/named-prepared-query/named-prepared-query-example.pony
@@ -59,13 +59,13 @@ actor Client is (SessionStatusNotify & ResultReceiver & PrepareReceiver)
     close()
 
   be pg_query_result(session: Session, result: Result) =>
-    match \exhaustive\ result
+    match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write("  " + field.name + "=")
-          match \exhaustive\ field.value
+          match field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/notice/notice-example.pony
+++ b/examples/notice/notice-example.pony
@@ -55,7 +55,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/parameter-status/parameter-status-example.pony
+++ b/examples/parameter-status/parameter-status-example.pony
@@ -52,7 +52,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/pipeline/pipeline-example.pony
+++ b/examples/pipeline/pipeline-example.pony
@@ -94,7 +94,7 @@ actor Client is
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)
@@ -130,7 +130,7 @@ actor Client is
     query: (PreparedQuery | NamedPreparedQuery),
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("  Pipeline query " + index.string() + " failed: ["
         + e.severity + "] " + e.code + ": " + e.message)

--- a/examples/prepared-query/prepared-query-example.pony
+++ b/examples/prepared-query/prepared-query-example.pony
@@ -44,13 +44,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match \exhaustive\ result
+    match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write("  " + field.name + "=")
-          match \exhaustive\ field.value
+          match field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/query/query-example.pony
+++ b/examples/query/query-example.pony
@@ -39,13 +39,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match \exhaustive\ result
+    match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match \exhaustive\ field.value
+          match field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/ssl-preferred-query/ssl-preferred-query-example.pony
+++ b/examples/ssl-preferred-query/ssl-preferred-query-example.pony
@@ -68,13 +68,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match \exhaustive\ result
+    match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match \exhaustive\ field.value
+          match field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/ssl-query/ssl-query-example.pony
+++ b/examples/ssl-query/ssl-query-example.pony
@@ -63,13 +63,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_query_result(session: Session, result: Result) =>
-    match \exhaustive\ result
+    match result
     | let r: ResultSet =>
       _out.print("ResultSet (" + r.rows().size().string() + " rows):")
       for row in r.rows().values() do
         for field in row.fields.values() do
           _out.write(field.name + "=")
-          match \exhaustive\ field.value
+          match field.value
           | let v: String => _out.print(v)
           | let v: I16 => _out.print(v.string())
           | let v: I32 => _out.print(v.string())

--- a/examples/streaming/streaming-example.pony
+++ b/examples/streaming/streaming-example.pony
@@ -86,7 +86,7 @@ actor Client is
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)
@@ -101,7 +101,7 @@ actor Client is
       _out.write("   ")
       for field in row.fields.values() do
         _out.write(" " + field.name + "=")
-        match \exhaustive\ field.value
+        match field.value
         | let v: String => _out.write(v)
         | let v: I32 => _out.write(v.string())
         | None => _out.write("NULL")
@@ -122,7 +122,7 @@ actor Client is
     query: (PreparedQuery | NamedPreparedQuery),
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Stream failed: [" + e.severity + "] " + e.code + ": "
         + e.message)

--- a/examples/transaction-status/transaction-status-example.pony
+++ b/examples/transaction-status/transaction-status-example.pony
@@ -41,7 +41,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
     _out.print("Failed to authenticate.")
 
   be pg_transaction_status(session: Session, status: TransactionStatus) =>
-    match \exhaustive\ status
+    match status
     | TransactionIdle => _out.print("Transaction status: idle")
     | TransactionInBlock => _out.print("Transaction status: in transaction")
     | TransactionFailed => _out.print("Transaction status: failed")
@@ -50,7 +50,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_result(session: Session, result: Result) =>
     _phase = _phase + 1
 
-    match \exhaustive\ _phase
+    match _phase
     | 1 =>
       // BEGIN done. Commit to return to idle.
       _session.execute(SimpleQuery("COMMIT"), this)
@@ -63,7 +63,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_query_failed(session: Session, query: Query,
     failure: (ErrorResponseMessage | ClientQueryError))
   =>
-    match \exhaustive\ failure
+    match failure
     | let e: ErrorResponseMessage =>
       _out.print("Query failed: [" + e.severity + "] " + e.code + ": "
         + e.message)


### PR DESCRIPTION
Examples weren't being compiled in CI, so breakage could go undetected until someone tried to build them locally.

Adds a `make examples` step to both the PR workflow and the nightly breakage workflow. Also removes all `\exhaustive\` match annotations from examples that were causing compile failures — `Result` is a trait (not exhaustible) and `_phase` matches on `USize` (infinite values).