### PR TITLE
Change Result and ClientQueryError from traits to union types

### DIFF
--- a/.release-notes/result-and-error-union-types.md
+++ b/.release-notes/result-and-error-union-types.md
@@ -1,0 +1,29 @@
+## Change Result and ClientQueryError from traits to union types
+
+`Result` and `ClientQueryError` are now union types instead of traits, enabling compiler-enforced exhaustive matching via `match \exhaustive\`. Previously, the compiler could not verify that all result or error variants were handled. Now, adding `\exhaustive\` to a match on `Result` or `ClientQueryError` produces a compile error if any variant is missing.
+
+This matches the pattern already used by `AuthenticationFailureReason`, `TransactionStatus`, `Query`, `SSLMode`, and `FieldDataTypes` in this library.
+
+Before:
+
+```pony
+be pg_query_result(session: Session, result: Result) =>
+  match result
+  | let r: ResultSet => // ...
+  | let r: RowModifying => // ...
+  // SimpleResult silently unhandled — no compiler warning
+  end
+```
+
+After:
+
+```pony
+be pg_query_result(session: Session, result: Result) =>
+  match \exhaustive\ result
+  | let r: ResultSet => // ...
+  | let r: RowModifying => // ...
+  | let r: SimpleResult => // ...
+  end
+```
+
+Existing non-exhaustive matches continue to work without changes. The `query()` method remains callable on all three `Result` members without matching first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Only one operation is in-flight at a time. The queue serializes execution. `quer
 - `SimpleQuery` — val class wrapping a query string (simple query protocol)
 - `PreparedQuery` — val class wrapping a query string + `Array[FieldDataTypes] val` params (extended query protocol, single statement only). Typed params (`I16`, `I32`, `I64`, `F32`, `F64`, `Bool`, `Array[U8] val`) use binary wire format with explicit OIDs; `String` and `None` use text format with server-inferred types
 - `NamedPreparedQuery` — val class wrapping a statement name + `Array[FieldDataTypes] val` params (executes a previously prepared named statement). Same typed parameter semantics as `PreparedQuery`
-- `Result` trait — `ResultSet` (rows), `SimpleResult` (no rows), `RowModifying` (INSERT/UPDATE/DELETE with count)
+- `Result` — union type `(ResultSet | RowModifying | SimpleResult)`
 - `Rows` / `Row` / `Field` — result data. `Field.value` is `FieldDataTypes` union
 - `FieldDataTypes` = `(Array[U8] val | Bool | F32 | F64 | I16 | I32 | I64 | None | String)`
 - `TransactionStatus` — union type `(TransactionIdle | TransactionInBlock | TransactionFailed)`. Reported via `pg_transaction_status` callback on every `ReadyForQuery`.
@@ -117,7 +117,7 @@ Only one operation is in-flight at a time. The queue serializes execution. `quer
 - `PipelineReceiver` interface (tag) — `pg_pipeline_result(Session, USize, Result)`, `pg_pipeline_failed(Session, USize, (PreparedQuery | NamedPreparedQuery), (ErrorResponseMessage | ClientQueryError))`, `pg_pipeline_complete(Session)`. Each query result/failure is delivered with its pipeline index. `pg_pipeline_complete` always fires last
 - `Codec` interface (val) — `format(): U16`, `encode(FieldDataTypes): Array[U8] val ?`, `decode(Array[U8] val): FieldDataTypes ?`. Wire format codec for a PostgreSQL type. Built-in codecs are primitives (zero-allocation singletons)
 - `CodecRegistry` class (val) — maps OIDs to text and binary `Codec` instances. Default constructor populates all built-in codecs. `decode(oid, format, data)` with fallbacks (unknown text→String, unknown binary→raw bytes). `has_binary_codec(oid)` for format selection
-- `ClientQueryError` trait — `SessionNeverOpened`, `SessionClosed`, `SessionNotAuthenticated`, `DataError`
+- `ClientQueryError` — union type `(SessionNeverOpened | SessionClosed | SessionNotAuthenticated | DataError)`
 - `DatabaseConnectInfo` — val class grouping database authentication parameters (user, password, database). Passed to `Session.create()` alongside `ServerConnectInfo`.
 - `ServerConnectInfo` — val class grouping connection parameters (auth, host, service, ssl_mode). Passed to `Session.create()` as the first parameter. Also used by `_CancelSender`.
 - `SSLMode` — union type `(SSLDisabled | SSLPreferred | SSLRequired)`. `SSLDisabled` is the default (plaintext). `SSLPreferred` wraps an `SSLContext val` and attempts SSL with plaintext fallback on server refusal (`sslmode=prefer`). `SSLRequired` wraps an `SSLContext val` and aborts on server refusal.

--- a/postgres/query_error.pony
+++ b/postgres/query_error.pony
@@ -1,17 +1,19 @@
-trait val ClientQueryError
-  """
-  A client-side error that prevented a query from being sent to the server.
-  Each subtype represents a specific pre-condition failure (session not open,
-  session closed, not authenticated, or malformed data).
-  """
+// A client-side error that prevented a query from being sent to the server.
+// Each member represents a specific pre-condition failure (session not open,
+// session closed, not authenticated, or malformed data).
+type ClientQueryError is
+  ( SessionNeverOpened
+  | SessionClosed
+  | SessionNotAuthenticated
+  | DataError )
 
-primitive SessionNeverOpened is ClientQueryError
+primitive SessionNeverOpened
   """
   Error returned when a query is attempted for a session that hasn't been opened
   yet or is in the process of being opened.
   """
 
-primitive SessionClosed is ClientQueryError
+primitive SessionClosed
   """
   Error returned when a query is attempted for a session that was closed or
   failed to open. Includes sessions that were closed by the user as well as
@@ -20,13 +22,13 @@ primitive SessionClosed is ClientQueryError
   errors.
   """
 
-primitive SessionNotAuthenticated is ClientQueryError
+primitive SessionNotAuthenticated
   """
   Error returned when a query is attempted for a session that is open but hasn't
   been authenticated yet.
   """
 
-primitive DataError is ClientQueryError
+primitive DataError
   """
   Error returned when result data from the server is in an unexpected format
   (e.g., column count mismatch across rows) or when a parameter value cannot

--- a/postgres/result.pony
+++ b/postgres/result.pony
@@ -1,12 +1,9 @@
-trait val Result
-  """
-  The result of a successfully executed query. Subtypes distinguish between
-  queries that return rows (`ResultSet`), queries that modify rows
-  (`RowModifying`), and queries that do neither (`SimpleResult`).
-  """
-  fun query(): Query
+// The result of a successfully executed query. Members distinguish between
+// queries that return rows (`ResultSet`), queries that modify rows
+// (`RowModifying`), and queries that do neither (`SimpleResult`).
+type Result is (ResultSet | RowModifying | SimpleResult)
 
-class val ResultSet is Result
+class val ResultSet
   """
   A query result containing rows. Returned for SELECT and other row-returning
   statements. Provides access to the returned `Rows` and the command tag
@@ -33,7 +30,7 @@ class val ResultSet is Result
   fun command(): String =>
     _command
 
-class val SimpleResult is Result
+class val SimpleResult
   """
   A query result for statements that return no rows and report no row count.
   Returned for empty queries (the `EmptyQueryResponse` case).
@@ -46,7 +43,7 @@ class val SimpleResult is Result
   fun query(): Query =>
     _query
 
-class val RowModifying is Result
+class val RowModifying
   """
   A query result for statements that modify rows (INSERT, UPDATE, DELETE).
   Provides the command tag string and the number of rows affected.


### PR DESCRIPTION
Converts `Result` and `ClientQueryError` from traits to union types, enabling compiler-enforced exhaustive matching via `match \exhaustive\`. This matches the pattern already used by `AuthenticationFailureReason`, `TransactionStatus`, `Query`, `SSLMode`, and `FieldDataTypes` in this library.

Existing non-exhaustive matches and `result.query()` calls continue to work without changes.