### PR TITLE
Add missing tests and fix weak assertions from PR #150

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ Custom type decoding via `CodecRegistry.with_codec()`. Defines a `Point` class i
 
 ## query
 
-Minimal example using `SimpleQuery`. Connects, authenticates, executes `SELECT 525600::text`, and prints the result by iterating rows and matching on `FieldDataTypes`. Start here if you're new to the library.
+Minimal example using `SimpleQuery`. Connects, authenticates, executes `SELECT 525600::text`, and prints the result by iterating rows and matching on field value types. Start here if you're new to the library.
 
 ## prepared-query
 

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -374,6 +374,10 @@ actor \nodoc\ Main is TestList
     test(_TestFieldInequalityCustomType)
     test(_TestFieldEqualityCustomWithoutEquatable)
     test(_TestFieldEqualityCustomVsBuiltin)
+    test(_TestFieldEqualityCustomEquatableVsNonEquatable)
+    test(_TestCodecRegistryWithCodecCustomText)
+    test(Property1UnitTest[(I64, I64)](
+      _TestFieldCustomEqualityReflexiveProperty))
 
 class \nodoc\ iso _TestAuthenticate is UnitTest
   """

--- a/postgres/_test_codecs.pony
+++ b/postgres/_test_codecs.pony
@@ -2895,14 +2895,16 @@ class \nodoc\ iso _TestCodecRegistryWithCodecOverride is UnitTest
     "CodecRegistry/WithCodec/Override"
 
   fun apply(h: TestHelper) =>
-    // Override built-in bool codec
+    // Override built-in bool codec with point codec
     let reg = CodecRegistry.with_codec(16, _TestPointCodec)
     // OID 16 is normally bool; with override, it should try point codec
     // which expects 16 bytes, not 1 — so it should error and fall back
+    // to RawBytes (unknown binary fallback)
     let data: Array[U8] val = recover val [1] end
     match reg.decode(16, 1, data)
-    | let _: RawBytes => h.assert_true(true) // Falls back
-    else h.assert_true(true) // Any non-error result is fine
+    | let r: RawBytes =>
+      h.assert_array_eq[U8](data, r.data)
+    else h.fail("Expected RawBytes fallback when overridden codec errors")
     end
 
 class \nodoc\ iso _TestCodecRegistryWithCodecChaining is UnitTest
@@ -3018,3 +3020,57 @@ class \nodoc\ iso _TestFieldEqualityCustomVsBuiltin is UnitTest
     let p = _TestPoint(1.0, 2.0)
     h.assert_false(Field("x", p) == Field("x", I32(42)))
     h.assert_false(Field("x", I32(42)) == Field("x", p))
+
+class \nodoc\ iso _TestFieldEqualityCustomEquatableVsNonEquatable is UnitTest
+  """
+  Verifies symmetry when comparing a custom type with FieldDataEquatable
+  against a custom type without it. Neither direction should be equal.
+  """
+  fun name(): String =>
+    "Field/Equality/CustomEquatableVsNonEquatable"
+
+  fun apply(h: TestHelper) =>
+    let equatable = _TestPoint(1.0, 2.0)
+    let opaque = _TestOpaqueData("(1.0,2.0)")
+    // FieldDataEquatable dispatches to _TestPoint.field_data_eq which returns
+    // false for non-_TestPoint types
+    h.assert_false(Field("x", equatable) == Field("x", opaque))
+    // _TestOpaqueData has no FieldDataEquatable, falls to else false
+    h.assert_false(Field("x", opaque) == Field("x", equatable))
+
+// ---------------------------------------------------------------------------
+// Custom text codec test
+// ---------------------------------------------------------------------------
+
+primitive \nodoc\ _TestUppercaseTextCodec is Codec
+  """
+  Trivial custom text codec for testing the text branch of with_codec.
+  Decodes by uppercasing the input.
+  """
+  fun format(): U16 => 0
+
+  fun encode(value: FieldDataTypes): Array[U8] val ? =>
+    error
+
+  fun decode(data: Array[U8] val): FieldData =>
+    let s = String.from_array(data)
+    recover val s.upper() end
+
+class \nodoc\ iso _TestCodecRegistryWithCodecCustomText is UnitTest
+  fun name(): String =>
+    "CodecRegistry/WithCodec/CustomTextCodec"
+
+  fun apply(h: TestHelper) =>
+    let reg = CodecRegistry.with_codec(99900, _TestUppercaseTextCodec)
+    // Custom text codec should decode via the text codec map
+    let data: Array[U8] val = "hello".array()
+    match reg.decode(99900, 0, data)
+    | let s: String => h.assert_eq[String]("HELLO", s)
+    else h.fail("Expected String from custom text codec")
+    end
+    // Binary format for same OID should fall back to RawBytes
+    // (no binary codec registered)
+    match reg.decode(99900, 1, data)
+    | let r: RawBytes => h.assert_array_eq[U8](data, r.data)
+    else h.fail("Expected RawBytes fallback for binary format of text-only codec")
+    end

--- a/postgres/_test_equality.pony
+++ b/postgres/_test_equality.pony
@@ -5,9 +5,8 @@ use "pony_test"
 
 class \nodoc\ iso _TestFieldEqualityReflexive is UnitTest
   """
-  Every FieldDataTypes variant produces a Field that is equal to itself.
-  Covers all 13 variants of the FieldDataTypes union to verify each match
-  branch in Field.eq.
+  Every built-in FieldData type produces a Field that is equal to itself.
+  Covers all 14 built-in types to verify each match branch in Field.eq.
   """
   fun name(): String => "Field/Equality/Reflexive"
 
@@ -36,7 +35,7 @@ class \nodoc\ iso _TestFieldEqualityReflexive is UnitTest
 class \nodoc\ iso _TestFieldEqualityStructural is UnitTest
   """
   Two independently constructed Fields with the same name and value are equal.
-  Covers all 13 variants of the FieldDataTypes union.
+  Covers all 14 built-in FieldData types.
   """
   fun name(): String => "Field/Equality/Structural"
 
@@ -63,6 +62,9 @@ class \nodoc\ iso _TestFieldEqualityStructural is UnitTest
     h.assert_true(
       Field("a", PgTimestamp(1000)) == Field("a", PgTimestamp(1000)))
     h.assert_true(Field("a", "hello") == Field("a", "hello"))
+    h.assert_true(
+      Field("a", RawBytes(recover val [as U8: 7; 8] end))
+        == Field("a", RawBytes(recover val [as U8: 7; 8] end)))
 
 class \nodoc\ iso _TestFieldEqualitySymmetric is UnitTest
   """
@@ -92,7 +94,7 @@ class \nodoc\ iso _TestFieldEqualitySymmetric is UnitTest
     let f8 = Field("x", I32(0))
     h.assert_true(f7.eq(f8) == f8.eq(f7))
 
-    // Array[U8] vs String
+    // Bytea vs String
     let f9 = Field("x", Bytea(recover val [as U8: 1; 2] end))
     let f10 = Field("x", "hello")
     h.assert_true(f9.eq(f10) == f10.eq(f9))
@@ -119,7 +121,7 @@ class \nodoc\ iso _TestFieldInequality is UnitTest
     h.assert_false(Field("a", None) == Field("a", I32(0)))
     h.assert_false(Field("a", I32(0)) == Field("a", None))
 
-    // Array[U8] vs different Array[U8]
+    // Bytea vs different Bytea
     h.assert_false(
       Field("a", Bytea(recover val [as U8: 1; 2] end))
         == Field("a", Bytea(recover val [as U8: 1; 3] end)))
@@ -127,7 +129,15 @@ class \nodoc\ iso _TestFieldInequality is UnitTest
       Field("a", Bytea(recover val [as U8: 1; 2] end))
         == Field("a", Bytea(recover val [as U8: 1; 2; 3] end)))
 
-    // Array[U8] vs String
+    // Bytea vs RawBytes (same underlying bytes, different types)
+    h.assert_false(
+      Field("a", Bytea(recover val [as U8: 1; 2] end))
+        == Field("a", RawBytes(recover val [as U8: 1; 2] end)))
+    h.assert_false(
+      Field("a", RawBytes(recover val [as U8: 1; 2] end))
+        == Field("a", Bytea(recover val [as U8: 1; 2] end)))
+
+    // Bytea vs String
     h.assert_false(
       Field("a", Bytea(recover val [as U8: 1; 2] end))
         == Field("a", "hello"))
@@ -463,3 +473,20 @@ class \nodoc\ iso _TestRowsReflexiveProperty is Property1[Rows]
 
   fun ref property(arg1: Rows, h: PropertyHelper) =>
     h.assert_true(arg1 == arg1)
+
+class \nodoc\ iso _TestFieldCustomEqualityReflexiveProperty
+  is Property1[(I64, I64)]
+  """
+  Fields containing custom FieldDataEquatable values are reflexively equal.
+  Uses generated I64 pairs converted to F64 to construct _TestPoint values.
+  """
+  fun name(): String => "Field/Equality/CustomReflexive/Property"
+
+  fun gen(): Generator[(I64, I64)] =>
+    Generators.zip2[I64, I64](
+      Generators.i64(),
+      Generators.i64())
+
+  fun ref property(arg1: (I64, I64), h: PropertyHelper) =>
+    let p = _TestPoint(F64.from[I64](arg1._1), F64.from[I64](arg1._2))
+    h.assert_true(Field("pt", p) == Field("pt", p))

--- a/postgres/_test_query.pony
+++ b/postgres/_test_query.pony
@@ -2067,8 +2067,8 @@ actor \nodoc\ _CopyInAbortRollbackClient is
 
 class \nodoc\ iso _TestQueryByteaResults is UnitTest
   """
-  Verifies that a bytea column is decoded from hex format into Array[U8] val
-  when queried from a real PostgreSQL server.
+  Verifies that a bytea column is decoded from hex format into Bytea when
+  queried from a real PostgreSQL server.
   """
   fun name(): String =>
     "integration/Query/ByteaResults"

--- a/postgres/_test_session.pony
+++ b/postgres/_test_session.pony
@@ -630,7 +630,7 @@ actor \nodoc\ _TerminateSentTestServer
 class \nodoc\ iso _TestByteaResultDecoding is UnitTest
   """
   Verifies that a bytea column (OID 17) is decoded from PostgreSQL's hex
-  format into Array[U8] val. Uses a mock server that sends RowDescription
+  format into Bytea. Uses a mock server that sends RowDescription
   with a bytea column followed by a DataRow containing hex-encoded bytes.
   """
   fun name(): String =>
@@ -654,7 +654,7 @@ class \nodoc\ iso _TestByteaResultDecoding is UnitTest
 class \nodoc\ iso _TestEmptyByteaResultDecoding is UnitTest
   """
   Verifies that an empty bytea value (just the \\x prefix) is decoded into
-  an empty Array[U8] val.
+  an empty Bytea.
   """
   fun name(): String =>
     "Bytea/EmptyResultDecoding"

--- a/postgres/field_data.pony
+++ b/postgres/field_data.pony
@@ -16,5 +16,8 @@ interface val FieldDataEquatable
   Opt-in equality for custom `FieldData` types used in `Field.eq()`. Built-in
   types use explicit match arms. Custom types implement this interface to
   participate in field equality comparisons.
+
+  Implementations must return `false` when `that` is a different type to
+  preserve symmetry of `Field.eq()`.
   """
   fun field_data_eq(that: FieldData box): Bool


### PR DESCRIPTION
Three tests and a property test were implemented locally but never committed to the branch before PR #150 was merged:

- `_TestFieldEqualityCustomEquatableVsNonEquatable` — verifies symmetry when comparing a `FieldDataEquatable` custom type against a non-equatable custom type
- `_TestCodecRegistryWithCodecCustomText` — verifies `with_codec` works for text-format codecs and that binary format correctly falls back to `RawBytes`
- `_TestFieldCustomEqualityReflexiveProperty` — property test for reflexive equality of custom `FieldDataEquatable` types

Also fixes a no-op assertion in `_TestCodecRegistryWithCodecOverride` (was `assert_true(true)`), adds `RawBytes` coverage to structural equality and inequality tests, and updates docstrings to reflect the `Bytea`/`RawBytes` type changes.