### PR TITLE
Add test-one Makefile target for running individual tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Pure Pony PostgreSQL driver. Alpha-level. Version 0.2.2.
 ```
 make ssl=3.0.x                        # build and run all tests
 make unit-tests ssl=3.0.x             # unit tests only (no postgres needed)
+make test-one t=TestName ssl=3.0.x    # run a single test by name
 make integration-tests ssl=3.0.x      # integration tests (needs postgres)
 make examples ssl=3.0.x               # compile examples
 make start-pg-containers              # docker postgres:14.5 on ports 5432 (plain) and 5433 (SSL)

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ test: unit-tests integration-tests examples
 unit-tests: $(tests_binary)
 	$^ --exclude=integration/ --sequential
 
+test-one: $(tests_binary)
+	$^ --only="$(t)"
+
 integration-tests: $(tests_binary)
 	$^ --only=integration/ --sequential
 
@@ -101,4 +104,4 @@ $(BUILD_DIR):
 $(COVERAGE_DIR):
 	mkdir -p $(COVERAGE_DIR)
 
-.PHONY: all examples clean docs TAGS test coverage start-pg-containers stop-pg-containers
+.PHONY: all examples clean docs TAGS test test-one coverage start-pg-containers stop-pg-containers


### PR DESCRIPTION
Adds a `test-one` target that runs a single test by name using ponytest's `--only` flag:

```
make test-one t=TestName ssl=3.0.x
```

Avoids full suite runs when iterating on a specific test during development or debugging. Also documents the target in CLAUDE.md.