### PR TITLE
Add ifdef bigendian guard to docstring and release notes examples

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -695,8 +695,16 @@ primitive PointBinaryCodec is Codec
 
   fun decode(data: Array[U8] val): FieldData ? =>
     if data.size() != 16 then error end
-    let x = F64.from_bits(data.read_u64(0)?.bswap())
-    let y = F64.from_bits(data.read_u64(8)?.bswap())
+    let x = ifdef bigendian then
+      F64.from_bits(data.read_u64(0)?)
+    else
+      F64.from_bits(data.read_u64(0)?.bswap())
+    end
+    let y = ifdef bigendian then
+      F64.from_bits(data.read_u64(8)?)
+    else
+      F64.from_bits(data.read_u64(8)?.bswap())
+    end
     Point(x, y)
 
 // Register and pass to Session

--- a/postgres/postgres.pony
+++ b/postgres/postgres.pony
@@ -372,8 +372,16 @@ primitive PointBinaryCodec is Codec
 
   fun decode(data: Array[U8] val): FieldData ? =>
     if data.size() != 16 then error end
-    let x = F64.from_bits(data.read_u64(0)?.bswap())
-    let y = F64.from_bits(data.read_u64(8)?.bswap())
+    let x = ifdef bigendian then
+      F64.from_bits(data.read_u64(0)?)
+    else
+      F64.from_bits(data.read_u64(0)?.bswap())
+    end
+    let y = ifdef bigendian then
+      F64.from_bits(data.read_u64(8)?)
+    else
+      F64.from_bits(data.read_u64(8)?.bswap())
+    end
     Point(x, y)
 
 // Register and pass to Session


### PR DESCRIPTION
The custom codec decode examples in the package docstring and release notes always called `.bswap()`, which is only correct on little-endian platforms. The example in `examples/custom-codec/` already had the correct `ifdef bigendian` guard. Updated both to match.

Closes #152