### PR TITLE
Dispose mock server connections and sessions in tests

### DIFF
--- a/postgres/_test_auth.pony
+++ b/postgres/_test_auth.pony
@@ -138,13 +138,16 @@ actor \nodoc\ _UnsupportedAuthenticationTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _UnsupportedAuthenticationTestServer =>
-    _UnsupportedAuthenticationTestServer(_server_auth, fd)
+    let server = _UnsupportedAuthenticationTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SCRAMFailureTestNotify(_h, UnsupportedAuthenticationMethod))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -250,7 +253,9 @@ actor \nodoc\ _SCRAMTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMTestServer =>
-    _SCRAMTestServer(_server_auth, fd, _h, _send_wrong_signature)
+    let server = _SCRAMTestServer(_server_auth, fd, _h, _send_wrong_signature)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
     let notify: SessionStatusNotify = if _send_wrong_signature then
@@ -258,10 +263,11 @@ actor \nodoc\ _SCRAMTestListener is lori.TCPListenerActor
     else
       _SCRAMSuccessTestNotify(_h)
     end
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -427,13 +433,16 @@ actor \nodoc\ _SCRAMUnsupportedTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMUnsupportedTestServer =>
-    _SCRAMUnsupportedTestServer(_server_auth, fd)
+    let server = _SCRAMUnsupportedTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SCRAMFailureTestNotify(_h, UnsupportedAuthenticationMethod))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -484,13 +493,16 @@ actor \nodoc\ _SCRAMErrorTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMErrorTestServer =>
-    _SCRAMErrorTestServer(_server_auth, fd)
+    let server = _SCRAMErrorTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SCRAMFailureTestNotify(_h, InvalidPassword))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_cancel.pony
+++ b/postgres/_test_cancel.pony
@@ -78,7 +78,9 @@ actor \nodoc\ _CancelTestListener is lori.TCPListenerActor
 
   fun ref _on_accept(fd: U32): _CancelTestServer =>
     _connection_count = _connection_count + 1
-    _CancelTestServer(_server_auth, fd, _h, _connection_count > 1)
+    let server = _CancelTestServer(_server_auth, fd, _h, _connection_count > 1)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
     let session = Session(
@@ -266,8 +268,10 @@ actor \nodoc\ _SSLCancelTestListener is lori.TCPListenerActor
 
   fun ref _on_accept(fd: U32): _SSLCancelTestServer =>
     _connection_count = _connection_count + 1
-    _SSLCancelTestServer(_server_auth, _server_sslctx, fd, _h,
+    let server = _SSLCancelTestServer(_server_auth, _server_sslctx, fd, _h,
       _connection_count > 1)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
     let session = Session(

--- a/postgres/_test_copy_in.pony
+++ b/postgres/_test_copy_in.pony
@@ -100,13 +100,16 @@ actor \nodoc\ _CopyInSuccessTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyInSuccessTestServer =>
-    _CopyInSuccessTestServer(_server_auth, fd)
+    let server = _CopyInSuccessTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyInSuccessTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -261,13 +264,16 @@ actor \nodoc\ _CopyInAbortTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyInAbortTestServer =>
-    _CopyInAbortTestServer(_server_auth, fd)
+    let server = _CopyInAbortTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyInAbortTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -434,13 +440,16 @@ actor \nodoc\ _CopyInServerErrorTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyInServerErrorTestServer =>
-    _CopyInServerErrorTestServer(_server_auth, fd)
+    let server = _CopyInServerErrorTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyInServerErrorTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -615,13 +624,16 @@ actor \nodoc\ _CopyInShutdownTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
-    _DoesntAnswerTestServer(_server_auth, fd)
+    let server = _DoesntAnswerTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyInShutdownTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_copy_out.pony
+++ b/postgres/_test_copy_out.pony
@@ -93,13 +93,16 @@ actor \nodoc\ _CopyOutSuccessTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyOutSuccessTestServer =>
-    _CopyOutSuccessTestServer(_server_auth, fd)
+    let server = _CopyOutSuccessTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyOutSuccessTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -253,13 +256,16 @@ actor \nodoc\ _CopyOutEmptyTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyOutEmptyTestServer =>
-    _CopyOutEmptyTestServer(_server_auth, fd)
+    let server = _CopyOutEmptyTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyOutEmptyTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -416,13 +422,16 @@ actor \nodoc\ _CopyOutServerErrorTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyOutServerErrorTestServer =>
-    _CopyOutServerErrorTestServer(_server_auth, fd)
+    let server = _CopyOutServerErrorTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyOutServerErrorTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -597,13 +606,16 @@ actor \nodoc\ _CopyOutShutdownTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
-    _DoesntAnswerTestServer(_server_auth, fd)
+    let server = _DoesntAnswerTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _CopyOutShutdownTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_notice.pony
+++ b/postgres/_test_notice.pony
@@ -215,13 +215,16 @@ actor \nodoc\ _NoticeTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NoticeTestServer =>
-    _NoticeTestServer(_server_auth, fd)
+    let server = _NoticeTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -299,13 +302,16 @@ actor \nodoc\ _NoticeMidQueryTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NoticeMidQueryTestServer =>
-    _NoticeMidQueryTestServer(_server_auth, fd)
+    let server = _NoticeMidQueryTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_notification.pony
+++ b/postgres/_test_notification.pony
@@ -216,13 +216,16 @@ actor \nodoc\ _NotificationTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NotificationTestServer =>
-    _NotificationTestServer(_server_auth, fd)
+    let server = _NotificationTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -300,13 +303,16 @@ actor \nodoc\ _NotificationMidQueryTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NotificationMidQueryTestServer =>
-    _NotificationMidQueryTestServer(_server_auth, fd)
+    let server = _NotificationMidQueryTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_parameter_status.pony
+++ b/postgres/_test_parameter_status.pony
@@ -208,13 +208,16 @@ actor \nodoc\ _ParameterStatusTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ParameterStatusTestServer =>
-    _ParameterStatusTestServer(_server_auth, fd)
+    let server = _ParameterStatusTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -292,13 +295,16 @@ actor \nodoc\ _ParameterStatusMidQueryTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ParameterStatusMidQueryTestServer =>
-    _ParameterStatusMidQueryTestServer(_server_auth, fd)
+    let server = _ParameterStatusMidQueryTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_pipeline.pony
+++ b/postgres/_test_pipeline.pony
@@ -103,13 +103,16 @@ actor \nodoc\ _PipelineSuccessTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineSuccessTestServer =>
-    _PipelineSuccessTestServer(_server_auth, fd)
+    let server = _PipelineSuccessTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineSuccessTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -283,13 +286,16 @@ actor \nodoc\ _PipelineWithFailureTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineWithFailureTestServer =>
-    _PipelineWithFailureTestServer(_server_auth, fd)
+    let server = _PipelineWithFailureTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineWithFailureTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -461,13 +467,16 @@ actor \nodoc\ _PipelineEmptyTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineEmptyTestServer =>
-    _PipelineEmptyTestServer(_server_auth, fd)
+    let server = _PipelineEmptyTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineEmptyTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -597,13 +606,16 @@ actor \nodoc\ _PipelineSingleQueryTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineSuccessTestServer =>
-    _PipelineSuccessTestServer(_server_auth, fd)
+    let server = _PipelineSuccessTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineSingleQueryTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -709,13 +721,16 @@ actor \nodoc\ _PipelineShutdownDrainsQueueTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
-    _DoesntAnswerTestServer(_server_auth, fd)
+    let server = _DoesntAnswerTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineShutdownDrainsQueueTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -826,13 +841,16 @@ actor \nodoc\ _PipelineShutdownInFlightTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineShutdownInFlightTestServer =>
-    _PipelineShutdownInFlightTestServer(_server_auth, fd)
+    let server = _PipelineShutdownInFlightTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineShutdownInFlightTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -1006,13 +1024,16 @@ actor \nodoc\ _PipelineRowModifyingTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineRowModifyingTestServer =>
-    _PipelineRowModifyingTestServer(_server_auth, fd)
+    let server = _PipelineRowModifyingTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineRowModifyingTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -1163,13 +1184,16 @@ actor \nodoc\ _PipelineMixedQueryTypesTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineSuccessTestServer =>
-    _PipelineSuccessTestServer(_server_auth, fd)
+    let server = _PipelineSuccessTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineMixedQueryTypesTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -1274,13 +1298,16 @@ actor \nodoc\ _PipelineAllFailTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineAllFailTestServer =>
-    _PipelineAllFailTestServer(_server_auth, fd)
+    let server = _PipelineAllFailTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PipelineAllFailTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_session.pony
+++ b/postgres/_test_session.pony
@@ -61,14 +61,17 @@ actor \nodoc\ _JunkSendingTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _JunkSendingTestServer =>
-    _JunkSendingTestServer(_server_auth, fd)
+    let server = _JunkSendingTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
     // Now that we are listening, start a client session
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _HandlingJunkTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -196,14 +199,17 @@ actor \nodoc\ _DoesntAnswerTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
-    _DoesntAnswerTestServer(_server_auth, fd)
+    let server = _DoesntAnswerTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
     // Now that we are listening, start a client session
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _DoesntAnswerClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -347,13 +353,16 @@ actor \nodoc\ _ZeroRowSelectTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ZeroRowSelectTestServer =>
-    _ZeroRowSelectTestServer(_server_auth, fd)
+    let server = _ZeroRowSelectTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _ZeroRowSelectTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -494,13 +503,16 @@ actor \nodoc\ _PrepareShutdownTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
-    _DoesntAnswerTestServer(_server_auth, fd)
+    let server = _DoesntAnswerTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _PrepareShutdownTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -571,13 +583,16 @@ actor \nodoc\ _TerminateSentTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TerminateSentTestServer =>
-    _TerminateSentTestServer(_server_auth, fd, _h)
+    let server = _TerminateSentTestServer(_server_auth, fd, _h)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _TerminateSentTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -759,13 +774,16 @@ actor \nodoc\ _ByteaTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ByteaTestServer =>
-    _ByteaTestServer(_server_auth, fd, _hex_data)
+    let server = _ByteaTestServer(_server_auth, fd, _hex_data)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _ByteaTestClient(_h, _expected))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -75,13 +75,16 @@ actor \nodoc\ _SSLRefusedTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLRefusedTestServer =>
-    _SSLRefusedTestServer(_server_auth, fd)
+    let server = _SSLRefusedTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port, SSLRequired(_sslctx)),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SSLRefusedTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -174,13 +177,16 @@ actor \nodoc\ _SSLJunkTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLJunkTestServer =>
-    _SSLJunkTestServer(_server_auth, fd)
+    let server = _SSLJunkTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port, SSLRequired(_sslctx)),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SSLJunkTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -299,13 +305,16 @@ actor \nodoc\ _SSLSuccessTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLSuccessTestServer =>
-    _SSLSuccessTestServer(_server_auth, _server_sslctx, fd)
+    let server = _SSLSuccessTestServer(_server_auth, _server_sslctx, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port, SSLRequired(_client_sslctx)),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SSLSuccessTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -551,14 +560,17 @@ actor \nodoc\ _SSLPreferredFallbackTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLPreferredFallbackTestServer =>
-    _SSLPreferredFallbackTestServer(_server_auth, fd)
+    let server = _SSLPreferredFallbackTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port,
         SSLPreferred(_sslctx)),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SSLPreferredFallbackTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -700,14 +712,17 @@ actor \nodoc\ _SSLPreferredSuccessTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLSuccessTestServer =>
-    _SSLSuccessTestServer(_server_auth, _server_sslctx, fd)
+    let server = _SSLSuccessTestServer(_server_auth, _server_sslctx, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port,
         SSLPreferred(_client_sslctx)),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SSLPreferredSuccessTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -808,14 +823,17 @@ actor \nodoc\ _SSLPreferredTLSFailureTestListener is lori.TCPListenerActor
   fun ref _on_accept(fd: U32): _SSLSuccessTestServer =>
     // Reuses _SSLSuccessTestServer — it responds 'S' and attempts TLS.
     // The incompatible TLS configs cause the handshake to fail.
-    _SSLSuccessTestServer(_server_auth, _server_sslctx, fd)
+    let server = _SSLSuccessTestServer(_server_auth, _server_sslctx, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port,
         SSLPreferred(_client_sslctx)),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _SSLPreferredTLSFailureTestNotify(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -894,8 +912,10 @@ actor \nodoc\ _SSLPreferredCancelTestListener is lori.TCPListenerActor
 
   fun ref _on_accept(fd: U32): _SSLPreferredCancelTestServer =>
     _connection_count = _connection_count + 1
-    _SSLPreferredCancelTestServer(_server_auth, _server_sslctx, fd, _h,
-      _connection_count > 1)
+    let server = _SSLPreferredCancelTestServer(_server_auth, _server_sslctx,
+      fd, _h, _connection_count > 1)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
     let session = Session(

--- a/postgres/_test_streaming.pony
+++ b/postgres/_test_streaming.pony
@@ -104,13 +104,16 @@ actor \nodoc\ _StreamingSuccessTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingSuccessTestServer =>
-    _StreamingSuccessTestServer(_server_auth, fd)
+    let server = _StreamingSuccessTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _StreamingSuccessTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -323,13 +326,16 @@ actor \nodoc\ _StreamingEmptyTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingEmptyTestServer =>
-    _StreamingEmptyTestServer(_server_auth, fd)
+    let server = _StreamingEmptyTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _StreamingEmptyTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -498,13 +504,16 @@ actor \nodoc\ _StreamingEarlyStopTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingEarlyStopTestServer =>
-    _StreamingEarlyStopTestServer(_server_auth, fd)
+    let server = _StreamingEarlyStopTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _StreamingEarlyStopTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -692,13 +701,16 @@ actor \nodoc\ _StreamingServerErrorTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingServerErrorTestServer =>
-    _StreamingServerErrorTestServer(_server_auth, fd)
+    let server = _StreamingServerErrorTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _StreamingServerErrorTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")
@@ -891,13 +903,16 @@ actor \nodoc\ _StreamingShutdownTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
-    _DoesntAnswerTestServer(_server_auth, fd)
+    let server = _DoesntAnswerTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _StreamingShutdownTestClient(_h))
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")

--- a/postgres/_test_transaction_status.pony
+++ b/postgres/_test_transaction_status.pony
@@ -264,13 +264,16 @@ actor \nodoc\ _TxnStatusTestListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TxnStatusTestServer =>
-    _TxnStatusTestServer(_server_auth, fd)
+    let server = _TxnStatusTestServer(_server_auth, fd)
+    _h.dispose_when_done(server)
+    server
 
   fun ref _on_listening() =>
-    Session(
+    let session = Session(
       ServerConnectInfo(lori.TCPConnectAuth(_h.env.root), _host, _port),
       DatabaseConnectInfo("postgres", "postgres", "postgres"),
       _notify)
+    _h.dispose_when_done(session)
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to listen")


### PR DESCRIPTION
Mock server test listeners create server actors in `_on_accept` and Session actors in `_on_listening` without registering them for disposal. When tests run with `--sequential` this doesn't matter because there's time between tests for the cleanup chain to complete. Without `--sequential`, all tests finish at roughly the same time and the undisposed actors keep their TCP connections open, preventing the Pony runtime from exiting.

Every mock server listener now registers both the accepted server connection and the client Session with `h.dispose_when_done()` so PonyTest closes them during teardown.

There's a separate lori issue (ponylang/lori#229) for `TCPConnectionActor.dispose()` using graceful close instead of hard close, which can leave sockets open intermittently due to an ASIO race condition. That's a lori concern. This PR is the postgres side: making sure we actually ask for disposal in the first place.