### PR TITLE
Change pg_session_connection_failed to include a failure reason

### DIFF
--- a/.release-notes/connection-failure-reason.md
+++ b/.release-notes/connection-failure-reason.md
@@ -1,0 +1,25 @@
+## Change pg_session_connection_failed to include a failure reason
+
+`pg_session_connection_failed` on `SessionStatusNotify` now takes a `ConnectionFailureReason` parameter indicating why the connection failed. This is a closed union type enabling exhaustive matching:
+
+Before:
+
+```pony
+be pg_session_connection_failed(session: Session) =>
+  _env.out.print("Connection failed")
+```
+
+After:
+
+```pony
+be pg_session_connection_failed(session: Session,
+  reason: ConnectionFailureReason)
+=>
+  match reason
+  | ConnectionFailedDNS => _env.out.print("DNS resolution failed")
+  | ConnectionFailedTCP => _env.out.print("TCP connection failed")
+  | SSLServerRefused => _env.out.print("Server refused SSL")
+  | TLSAuthFailed => _env.out.print("TLS certificate error")
+  | TLSHandshakeFailed => _env.out.print("TLS handshake failed")
+  end
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 2.0.0 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.8.1 (TCP networking, STARTTLS support)
+- `ponylang/lori` 0.11.0 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 
@@ -123,7 +123,7 @@ Only one operation is in-flight at a time. The queue serializes execution. `quer
 - `Notification` — val class wrapping channel name, payload string, and notifying backend's process ID. Delivered via `pg_notification` callback.
 - `NoticeResponseMessage` — non-fatal PostgreSQL notice with all standard fields (same structure as `ErrorResponseMessage`). Delivered via `pg_notice` callback.
 - `ParameterStatus` — val class wrapping a runtime parameter name and value reported by the server. Delivered via `pg_parameter_status` callback during startup and after SET commands.
-- `SessionStatusNotify` interface (tag) — lifecycle callbacks (connected, connection_failed, authenticated, authentication_failed, transaction_status, notification, notice, parameter_status, shutdown)
+- `SessionStatusNotify` interface (tag) — lifecycle callbacks (connected, connection_failed(reason), authenticated, authentication_failed, transaction_status, notification, notice, parameter_status, shutdown)
 - `ResultReceiver` interface (tag) — `pg_query_result(Session, Result)`, `pg_query_failed(Session, Query, (ErrorResponseMessage | ClientQueryError))`
 - `PrepareReceiver` interface (tag) — `pg_statement_prepared(Session, name)`, `pg_prepare_failed(Session, name, (ErrorResponseMessage | ClientQueryError))`
 - `CopyInReceiver` interface (tag) — `pg_copy_ready(Session)`, `pg_copy_complete(Session, count)`, `pg_copy_failed(Session, (ErrorResponseMessage | ClientQueryError))`. Pull-based: session calls `pg_copy_ready` after `copy_in` and after each `send_copy_data`, letting the client control data flow
@@ -138,6 +138,7 @@ Only one operation is in-flight at a time. The queue serializes execution. `quer
 - `SSLMode` — union type `(SSLDisabled | SSLPreferred | SSLRequired)`. `SSLDisabled` is the default (plaintext). `SSLPreferred` wraps an `SSLContext val` and attempts SSL with plaintext fallback on server refusal (`sslmode=prefer`). `SSLRequired` wraps an `SSLContext val` and aborts on server refusal.
 - `ErrorResponseMessage` — full PostgreSQL error with all standard fields
 - `AuthenticationFailureReason` = `(InvalidAuthenticationSpecification | InvalidPassword | ServerVerificationFailed | UnsupportedAuthenticationMethod)`
+- `ConnectionFailureReason` = `(ConnectionFailedDNS | ConnectionFailedTCP | SSLServerRefused | TLSAuthFailed | TLSHandshakeFailed)`. Delivered via `pg_session_connection_failed` callback
 
 ### Type Conversion (PostgreSQL OID → Pony)
 

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
    {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.8.1"
+      "version": "0.11.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/examples/ssl-preferred-query/ssl-preferred-query-example.pony
+++ b/examples/ssl-preferred-query/ssl-preferred-query-example.pony
@@ -52,7 +52,9 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_session_connected(session: Session) =>
     _out.print("Connected (SSL negotiation complete — may be encrypted or plaintext).")
 
-  be pg_session_connection_failed(session: Session) =>
+  be pg_session_connection_failed(session: Session,
+    reason: ConnectionFailureReason)
+  =>
     _out.print("Connection failed.")
 
   be pg_session_authenticated(session: Session) =>

--- a/examples/ssl-query/ssl-query-example.pony
+++ b/examples/ssl-query/ssl-query-example.pony
@@ -47,7 +47,9 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_session_connected(session: Session) =>
     _out.print("Connected (TLS handshake complete).")
 
-  be pg_session_connection_failed(session: Session) =>
+  be pg_session_connection_failed(session: Session,
+    reason: ConnectionFailureReason)
+  =>
     _out.print("Connection failed (server may not support SSL).")
 
   be pg_session_authenticated(session: Session) =>

--- a/postgres/_cancel_sender.pony
+++ b/postgres/_cancel_sender.pony
@@ -37,7 +37,11 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
       _send_cancel_and_close()
     | let _: (SSLRequired | SSLPreferred) =>
       // CVE-2021-23222 mitigation: expect exactly 1 byte for SSL response.
-      try _tcp_connection.expect(1)? end
+      match \exhaustive\ lori.MakeExpect(1)
+      | let e: lori.Expect => _tcp_connection.expect(e)
+      else
+        _Unreachable()
+      end
       _tcp_connection.send(_FrontendMessage.ssl_request())
     end
 
@@ -61,7 +65,7 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
         match _info.ssl_mode
         | let _: SSLPreferred =>
           // SSLPreferred: fall back to plaintext cancel
-          try _tcp_connection.expect(0)? end
+          _tcp_connection.expect(None)
           _send_cancel_and_close()
         else
           // SSLRequired or unexpected: silently give up
@@ -76,10 +80,10 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
 
   fun ref _on_tls_ready() =>
     // Reset expect from 1 back to 0 (same pattern as _SessionSSLNegotiating)
-    try _tcp_connection.expect(0)? end
+    _tcp_connection.expect(None)
     _send_cancel_and_close()
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: lori.TLSFailureReason) =>
     // Fire-and-forget: TLS handshake failed, silently give up.
     // Lori follows this with _on_closed() (default no-op), so no
     // additional cleanup needed.

--- a/postgres/_mort.pony
+++ b/postgres/_mort.pony
@@ -1,6 +1,6 @@
-use @exit[None](status: U8)
-use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
-use @pony_os_stderr[Pointer[U8]]()
+use @exit[None](status: I32)
+use @fprintf[I32](stream: Pointer[None] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[None]]()
 
 primitive _IllegalState
   """

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -565,7 +565,9 @@ actor \nodoc\ _ConnectTestNotify is SessionStatusNotify
   be pg_session_connected(session: Session) =>
     _h.complete(_success_expected == true)
 
-  be pg_session_connection_failed(session: Session) =>
+  be pg_session_connection_failed(session: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.complete(_success_expected == false)
 
 class \nodoc\ val _ConnectionTestConfiguration

--- a/postgres/_test_auth.pony
+++ b/postgres/_test_auth.pony
@@ -185,7 +185,9 @@ actor \nodoc\ _SCRAMSuccessTestNotify is SessionStatusNotify
     session.close()
     _h.complete(true)
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -208,7 +210,9 @@ actor \nodoc\ _SCRAMFailureTestNotify is SessionStatusNotify
     _h.fail("Should not have authenticated.")
     _h.complete(false)
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_cancel.pony
+++ b/postgres/_test_cancel.pony
@@ -31,7 +31,9 @@ actor \nodoc\ _CancelTestClient is (SessionStatusNotify & ResultReceiver)
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_copy_in.pony
+++ b/postgres/_test_copy_in.pony
@@ -32,7 +32,9 @@ actor \nodoc\ _CopyInSuccessTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -203,7 +205,9 @@ actor \nodoc\ _CopyInAbortTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -366,7 +370,9 @@ actor \nodoc\ _CopyInServerErrorTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -563,7 +569,9 @@ actor \nodoc\ _CopyInShutdownTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_copy_out.pony
+++ b/postgres/_test_copy_out.pony
@@ -32,7 +32,9 @@ actor \nodoc\ _CopyOutSuccessTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -195,7 +197,9 @@ actor \nodoc\ _CopyOutEmptyTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -351,7 +355,9 @@ actor \nodoc\ _CopyOutServerErrorTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -545,7 +551,9 @@ actor \nodoc\ _CopyOutShutdownTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -706,7 +714,9 @@ actor \nodoc\ _CopyOutExportTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_notice.pony
+++ b/postgres/_test_notice.pony
@@ -83,7 +83,9 @@ actor \nodoc\ _NoticeDeliveryClient
       _h.complete(true)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -173,7 +175,9 @@ actor \nodoc\ _NoticeDuringDataRowsClient
       _h.complete(true)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_notification.pony
+++ b/postgres/_test_notification.pony
@@ -84,7 +84,9 @@ actor \nodoc\ _NotificationDeliveryClient
       _h.complete(true)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -174,7 +176,9 @@ actor \nodoc\ _NotificationDuringDataRowsClient
       _h.complete(true)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_parameter_status.pony
+++ b/postgres/_test_parameter_status.pony
@@ -76,7 +76,9 @@ actor \nodoc\ _ParameterStatusDeliveryClient
       _h.complete(true)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -166,7 +168,9 @@ actor \nodoc\ _ParameterStatusDuringDataRowsClient
       _h.complete(true)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_pipeline.pony
+++ b/postgres/_test_pipeline.pony
@@ -32,7 +32,9 @@ actor \nodoc\ _PipelineSuccessTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -213,7 +215,9 @@ actor \nodoc\ _PipelineWithFailureTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -402,7 +406,9 @@ actor \nodoc\ _PipelineEmptyTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -536,7 +542,9 @@ actor \nodoc\ _PipelineSingleQueryTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -652,7 +660,9 @@ actor \nodoc\ _PipelineShutdownDrainsQueueTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -767,7 +777,9 @@ actor \nodoc\ _PipelineShutdownInFlightTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -949,7 +961,9 @@ actor \nodoc\ _PipelineRowModifyingTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -1115,7 +1129,9 @@ actor \nodoc\ _PipelineMixedQueryTypesTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -1229,7 +1245,9 @@ actor \nodoc\ _PipelineAllFailTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_query.pony
+++ b/postgres/_test_query.pony
@@ -171,7 +171,9 @@ actor \nodoc\ _QueryAfterConnectionFailureNotify is
     _h.fail("Unexpected successful connection")
     _h.complete(false)
 
-  be pg_session_connection_failed(session: Session) =>
+  be pg_session_connection_failed(session: Session,
+    reason: ConnectionFailureReason)
+  =>
     session.execute(_query, this)
 
   be pg_query_result(session: Session, result: Result) =>

--- a/postgres/_test_session.pony
+++ b/postgres/_test_session.pony
@@ -31,7 +31,9 @@ actor \nodoc\ _HandlingJunkTestNotify is SessionStatusNotify
   be pg_session_shutdown(s: Session) =>
     _h.complete(true)
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection")
     _h.complete(false)
 
@@ -87,11 +89,13 @@ actor \nodoc\ _JunkSendingTestServer
 
   new create(auth: lori.TCPServerAuth, fd: U32) =>
     _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
-    let junk = _IncomingJunkTestMessage.bytes()
-    _tcp_connection.send(junk)
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_started() =>
+    let junk = _IncomingJunkTestMessage.bytes()
+    _tcp_connection.send(junk)
 
   fun ref _on_received(data: Array[U8] iso) =>
     let junk = _IncomingJunkTestMessage.bytes()
@@ -130,7 +134,9 @@ actor \nodoc\ _DoesntAnswerClient is (SessionStatusNotify & ResultReceiver)
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -277,7 +283,9 @@ actor \nodoc\ _ZeroRowSelectTestClient is (SessionStatusNotify & ResultReceiver)
     _h = h
     _query = SimpleQuery("SELECT * FROM empty_table")
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -446,7 +454,9 @@ actor \nodoc\ _PrepareShutdownTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -550,7 +560,9 @@ actor \nodoc\ _TerminateSentTestNotify is SessionStatusNotify
   be pg_session_authenticated(session: Session) =>
     session.close()
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -700,7 +712,9 @@ actor \nodoc\ _ByteaTestClient is (SessionStatusNotify & ResultReceiver)
     _expected = expected
     _query = SimpleQuery("SELECT col")
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -39,7 +39,9 @@ actor \nodoc\ _SSLRefusedTestNotify is SessionStatusNotify
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.complete(true)
 
   be pg_session_connected(s: Session) =>
@@ -148,7 +150,9 @@ actor \nodoc\ _SSLJunkTestNotify is SessionStatusNotify
     _h.fail("Should not have connected")
     _h.complete(false)
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Should not have gotten connection_failed for junk")
     _h.complete(false)
 
@@ -267,7 +271,9 @@ actor \nodoc\ _SSLSuccessTestNotify is SessionStatusNotify
     session.close()
     _h.complete(true)
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Connection failed during SSL negotiation")
     _h.complete(false)
 
@@ -525,7 +531,9 @@ actor \nodoc\ _SSLPreferredFallbackTestNotify is SessionStatusNotify
       _h.complete(false)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Should not have gotten connection_failed with SSLPreferred")
     _h.complete(false)
 
@@ -674,7 +682,9 @@ actor \nodoc\ _SSLPreferredSuccessTestNotify is SessionStatusNotify
     session.close()
     _h.complete(true)
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Connection failed during SSL negotiation")
     _h.complete(false)
 
@@ -782,7 +792,9 @@ actor \nodoc\ _SSLPreferredTLSFailureTestNotify is SessionStatusNotify
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.complete(true)
 
   be pg_session_connected(s: Session) =>

--- a/postgres/_test_streaming.pony
+++ b/postgres/_test_streaming.pony
@@ -34,7 +34,9 @@ actor \nodoc\ _StreamingSuccessTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -263,7 +265,9 @@ actor \nodoc\ _StreamingEmptyTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -439,7 +443,9 @@ actor \nodoc\ _StreamingEarlyStopTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -626,7 +632,9 @@ actor \nodoc\ _StreamingServerErrorTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -837,7 +845,9 @@ actor \nodoc\ _StreamingShutdownTestClient is
   new create(h: TestHelper) =>
     _h = h
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/_test_transaction_status.pony
+++ b/postgres/_test_transaction_status.pony
@@ -40,7 +40,9 @@ actor \nodoc\ _TxnStatusOnAuthClient is SessionStatusNotify
       _h.complete(true)
     end
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -128,7 +130,9 @@ actor \nodoc\ _TxnStatusDuringTxnClient is (SessionStatusNotify & ResultReceiver
     session.close()
     _h.complete(false)
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
@@ -226,7 +230,9 @@ actor \nodoc\ _TxnStatusFailedClient is (SessionStatusNotify & ResultReceiver)
     // Expected — the invalid query should fail
     None
 
-  be pg_session_connection_failed(s: Session) =>
+  be pg_session_connection_failed(s: Session,
+    reason: ConnectionFailureReason)
+  =>
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 

--- a/postgres/connection_failure_reason.pony
+++ b/postgres/connection_failure_reason.pony
@@ -1,0 +1,28 @@
+primitive ConnectionFailedDNS
+  """
+  Name resolution failed — the server hostname could not be resolved.
+  """
+
+primitive ConnectionFailedTCP
+  """
+  TCP connection failed — the server is not reachable.
+  """
+
+primitive SSLServerRefused
+  """
+  The server refused the SSL request.
+  """
+
+primitive TLSAuthFailed
+  """
+  TLS certificate or authentication verification failed.
+  """
+
+primitive TLSHandshakeFailed
+  """
+  The TLS handshake failed.
+  """
+
+type ConnectionFailureReason is
+  (ConnectionFailedDNS | ConnectionFailedTCP |
+   SSLServerRefused | TLSAuthFailed | TLSHandshakeFailed)

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -179,8 +179,13 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   fun ref _on_connected() =>
     state.on_connected(this)
 
-  fun ref _on_connection_failure() =>
-    state.on_failure(this)
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+    let r: ConnectionFailureReason = match \exhaustive\ reason
+    | let _: lori.ConnectionFailedDNS => ConnectionFailedDNS
+    | let _: lori.ConnectionFailedTCP => ConnectionFailedTCP
+    | let _: lori.ConnectionFailedSSL => TLSHandshakeFailed
+    end
+    state.on_failure(this, r)
 
   fun ref _on_received(data: Array[U8] iso) =>
     state.on_received(this, consume data)
@@ -193,8 +198,12 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   fun ref _on_tls_ready() =>
     state.on_tls_ready(this)
 
-  fun ref _on_tls_failure() =>
-    state.on_tls_failure(this)
+  fun ref _on_tls_failure(reason: lori.TLSFailureReason) =>
+    let r: ConnectionFailureReason = match \exhaustive\ reason
+    | let _: lori.TLSAuthFailed => TLSAuthFailed
+    | let _: lori.TLSGeneralError => TLSHandshakeFailed
+    end
+    state.on_tls_failure(this, r)
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
@@ -365,13 +374,13 @@ class ref _SessionSSLNegotiating
         | None =>
           _handshake_started = true
         | let _: lori.StartTLSError =>
-          _connection_failed(s)
+          _connection_failed(s, TLSHandshakeFailed)
         end
       elseif response == 'N' then
         if _fallback_on_refusal then
           _proceed_to_connected(s)
         else
-          _connection_failed(s)
+          _connection_failed(s, SSLServerRefused)
         end
       else
         _shutdown(s)
@@ -388,7 +397,7 @@ class ref _SessionSSLNegotiating
     // bytes). Critical: lori preserves the expect(1) value across start_tls()
     // via _ssl_expect. Without this reset, decrypted data would be delivered
     // 1 byte at a time, breaking _ResponseParser.
-    try s._connection().expect(0)? end
+    s._connection().expect(None)
     s.state = _SessionConnected(_notify, _database_connect_info,
       _codec_registry)
     _notify.pg_session_connected(s)
@@ -396,8 +405,10 @@ class ref _SessionSSLNegotiating
       _database_connect_info.user, _database_connect_info.database)
     s._connection().send(msg)
 
-  fun ref on_tls_failure(s: Session ref) =>
-    _notify.pg_session_connection_failed(s)
+  fun ref on_tls_failure(s: Session ref,
+    reason: ConnectionFailureReason)
+  =>
+    _notify.pg_session_connection_failed(s, reason)
     s.state = _SessionClosed
 
   fun ref execute(s: Session ref, q: Query, r: ResultReceiver) =>
@@ -471,9 +482,11 @@ class ref _SessionSSLNegotiating
   fun ref shutdown(s: Session ref) =>
     _shutdown(s)
 
-  fun ref _connection_failed(s: Session ref) =>
+  fun ref _connection_failed(s: Session ref,
+    reason: ConnectionFailureReason)
+  =>
     s._connection().close()
-    _notify.pg_session_connection_failed(s)
+    _notify.pg_session_connection_failed(s, reason)
     s.state = _SessionClosed
 
   fun ref _shutdown(s: Session ref) =>
@@ -2380,7 +2393,7 @@ interface _SessionState
     """
     Called when a connection is established with the server.
     """
-  fun on_failure(s: Session ref)
+  fun on_failure(s: Session ref, reason: ConnectionFailureReason)
     """
     Called if we fail to establish a connection with the server.
     """
@@ -2388,7 +2401,7 @@ interface _SessionState
     """
     Called when a TLS handshake initiated by start_tls() completes.
     """
-  fun ref on_tls_failure(s: Session ref)
+  fun ref on_tls_failure(s: Session ref, reason: ConnectionFailureReason)
     """
     Called when a TLS handshake initiated by start_tls() fails.
     """
@@ -2642,16 +2655,20 @@ trait _ConnectableState is _UnconnectedState
     // one byte per _on_received call. Any MITM-injected bytes stay in
     // lori's internal buffer, causing start_tls() to return
     // StartTLSNotReady (CVE-2021-23222 mitigation).
-    try s._connection().expect(1)? end
+    match \exhaustive\ lori.MakeExpect(1)
+    | let e: lori.Expect => s._connection().expect(e)
+    else
+      _Unreachable()
+    end
     let st = _SessionSSLNegotiating(
       notify(), database_connect_info(), ctx, host(),
       fallback_on_refusal, codec_registry())
     s.state = st
     st.send_ssl_request(s)
 
-  fun on_failure(s: Session ref) =>
+  fun on_failure(s: Session ref, reason: ConnectionFailureReason) =>
     s.state = _SessionClosed
-    notify().pg_session_connection_failed(s)
+    notify().pg_session_connection_failed(s, reason)
 
   fun _send_startup_message(s: Session ref) =>
     let dci = database_connect_info()
@@ -2672,7 +2689,7 @@ trait _NotConnectableState
   fun on_connected(s: Session ref) =>
     _IllegalState()
 
-  fun on_failure(s: Session ref) =>
+  fun on_failure(s: Session ref, reason: ConnectionFailureReason) =>
     _IllegalState()
 
 trait _ConnectedState is _NotConnectableState
@@ -2692,7 +2709,9 @@ trait _ConnectedState is _NotConnectableState
   fun ref on_tls_ready(s: Session ref) =>
     _IllegalState()
 
-  fun ref on_tls_failure(s: Session ref) =>
+  fun ref on_tls_failure(s: Session ref,
+    reason: ConnectionFailureReason)
+  =>
     _IllegalState()
   fun ref on_received(s: Session ref, data: Array[U8] iso) =>
     readbuf().append(consume data)
@@ -2755,7 +2774,9 @@ trait _UnconnectedState is (_NotAuthenticableState & _NotAuthenticated)
   fun ref on_tls_ready(s: Session ref) =>
     _IllegalState()
 
-  fun ref on_tls_failure(s: Session ref) =>
+  fun ref on_tls_failure(s: Session ref,
+    reason: ConnectionFailureReason)
+  =>
     _IllegalState()
   fun ref on_received(s: Session ref, data: Array[U8] iso) =>
     // It is possible we will continue to receive data after we have closed

--- a/postgres/session_status_notify.pony
+++ b/postgres/session_status_notify.pony
@@ -12,7 +12,9 @@ interface tag SessionStatusNotify
     """
     None
 
-  be pg_session_connection_failed(session: Session) =>
+  be pg_session_connection_failed(session: Session,
+    reason: ConnectionFailureReason)
+  =>
     """
     Called when we have failed to connect to the server before attempting to
     authenticate.


### PR DESCRIPTION
Adapts postgres internals to three breaking lori releases between 0.8.1 and 0.11.0:

- **0.9.0**: `_on_connection_failure()` and `_on_tls_failure()` now take a reason parameter
- **0.11.0**: `expect()` takes `(Expect | None)` instead of `USize`

The lori failure reasons are now threaded through the state machine to the public API: `pg_session_connection_failed` on `SessionStatusNotify` takes a `ConnectionFailureReason` — a closed union of `ConnectionFailedDNS`, `ConnectionFailedTCP`, `SSLServerRefused`, `TLSAuthFailed`, and `TLSHandshakeFailed`.

Other mechanical changes: FFI declarations in `_mort.pony` updated to match lori's, a mock server test fixed (moved `send()` from constructor to `_on_started()`), and `MakeExpect(1)` matches made exhaustive with `_Unreachable()`.

Closes #161