### PR TITLE
Use _Unreachable() in Row.eq() and Rows.eq() else branches

### DIFF
--- a/postgres/row.pony
+++ b/postgres/row.pony
@@ -23,5 +23,6 @@ class val Row is Equatable[Row]
       end
       true
     else
+      _Unreachable()
       false
     end

--- a/postgres/rows.pony
+++ b/postgres/rows.pony
@@ -35,6 +35,7 @@ class val Rows is Equatable[Rows]
       end
       true
     else
+      _Unreachable()
       false
     end
 


### PR DESCRIPTION
The `try`/`else` branches in both methods guard array accesses that are already bounds-checked by the size comparison above, making the `else` path unreachable. Using `_Unreachable()` enforces that invariant at runtime instead of silently returning `false`.

Closes #149