### PR TITLE
Update ponylang/ssl to 2.0.1

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -9,7 +9,7 @@
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.0"
+      "version": "2.0.1"
     }
   ],
   "info": {


### PR DESCRIPTION
Updates the ponylang/ssl dependency to 2.0.1 to pick up a bug fix.