### PR TITLE
Add ConnectionFailedTimeout to ConnectionFailureReason

### DIFF
--- a/.release-notes/connection-failed-timeout.md
+++ b/.release-notes/connection-failed-timeout.md
@@ -1,0 +1,28 @@
+## Add ConnectionFailedTimeout to ConnectionFailureReason
+
+`ConnectionFailureReason` now includes `ConnectionFailedTimeout` for when a connection attempt times out before a TCP or TLS connection is established. If you have an exhaustive match on `ConnectionFailureReason`, you'll need to add the new arm:
+
+Before:
+
+```pony
+match reason
+| ConnectionFailedDNS => _env.out.print("DNS resolution failed")
+| ConnectionFailedTCP => _env.out.print("TCP connection failed")
+| SSLServerRefused => _env.out.print("Server refused SSL")
+| TLSAuthFailed => _env.out.print("TLS certificate error")
+| TLSHandshakeFailed => _env.out.print("TLS handshake failed")
+end
+```
+
+After:
+
+```pony
+match reason
+| ConnectionFailedDNS => _env.out.print("DNS resolution failed")
+| ConnectionFailedTCP => _env.out.print("TCP connection failed")
+| SSLServerRefused => _env.out.print("Server refused SSL")
+| TLSAuthFailed => _env.out.print("TLS certificate error")
+| TLSHandshakeFailed => _env.out.print("TLS handshake failed")
+| ConnectionFailedTimeout => _env.out.print("Connection timed out")
+end
+```

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -822,6 +822,7 @@ be pg_session_connection_failed(session: Session,
   | SSLServerRefused => _env.out.print("Server refused SSL")
   | TLSAuthFailed => _env.out.print("TLS certificate error")
   | TLSHandshakeFailed => _env.out.print("TLS handshake failed")
+  | ConnectionFailedTimeout => _env.out.print("Connection timed out")
   end
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 
 ## Dependencies
 
-- `ponylang/ssl` 2.0.0 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.11.0 (TCP networking, STARTTLS support)
+- `ponylang/ssl` 2.0.1 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
+- `ponylang/lori` 0.12.0 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 
@@ -138,7 +138,7 @@ Only one operation is in-flight at a time. The queue serializes execution. `quer
 - `SSLMode` — union type `(SSLDisabled | SSLPreferred | SSLRequired)`. `SSLDisabled` is the default (plaintext). `SSLPreferred` wraps an `SSLContext val` and attempts SSL with plaintext fallback on server refusal (`sslmode=prefer`). `SSLRequired` wraps an `SSLContext val` and aborts on server refusal.
 - `ErrorResponseMessage` — full PostgreSQL error with all standard fields
 - `AuthenticationFailureReason` = `(InvalidAuthenticationSpecification | InvalidPassword | ServerVerificationFailed | UnsupportedAuthenticationMethod)`
-- `ConnectionFailureReason` = `(ConnectionFailedDNS | ConnectionFailedTCP | SSLServerRefused | TLSAuthFailed | TLSHandshakeFailed)`. Delivered via `pg_session_connection_failed` callback
+- `ConnectionFailureReason` = `(ConnectionFailedDNS | ConnectionFailedTCP | SSLServerRefused | TLSAuthFailed | TLSHandshakeFailed | ConnectionFailedTimeout)`. Delivered via `pg_session_connection_failed` callback
 
 ### Type Conversion (PostgreSQL OID → Pony)
 
@@ -193,7 +193,7 @@ Tests live in the main `postgres/` package (private test classes), organized acr
 
 ## Supported PostgreSQL Features
 
-**SSL/TLS:** Optional SSL negotiation via `SSLRequired` (mandatory) or `SSLPreferred` (fallback to plaintext on server refusal). CVE-2021-23222 mitigated via `expect(1)` before SSLRequest. Design: [discussion #76](https://github.com/ponylang/postgres/discussions/76).
+**SSL/TLS:** Optional SSL negotiation via `SSLRequired` (mandatory) or `SSLPreferred` (fallback to plaintext on server refusal). CVE-2021-23222 mitigated via `buffer_until(BufferSize)` before SSLRequest. Design: [discussion #76](https://github.com/ponylang/postgres/discussions/76).
 
 **Authentication:** MD5 password and SCRAM-SHA-256. No SCRAM-SHA-256-PLUS (channel binding), Kerberos, GSS, or certificate auth. Design: [discussion #83](https://github.com/ponylang/postgres/discussions/83).
 

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
    {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.11.0"
+      "version": "0.12.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/postgres/_cancel_sender.pony
+++ b/postgres/_cancel_sender.pony
@@ -36,9 +36,9 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
     | SSLDisabled =>
       _send_cancel_and_close()
     | let _: (SSLRequired | SSLPreferred) =>
-      // CVE-2021-23222 mitigation: expect exactly 1 byte for SSL response.
-      match \exhaustive\ lori.MakeExpect(1)
-      | let e: lori.Expect => _tcp_connection.expect(e)
+      // CVE-2021-23222 mitigation: buffer exactly 1 byte for SSL response.
+      match \exhaustive\ lori.MakeBufferSize(1)
+      | let e: lori.BufferSize => _tcp_connection.buffer_until(e)
       else
         _Unreachable()
       end
@@ -65,7 +65,7 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
         match _info.ssl_mode
         | let _: SSLPreferred =>
           // SSLPreferred: fall back to plaintext cancel
-          _tcp_connection.expect(None)
+          _tcp_connection.buffer_until(lori.Streaming)
           _send_cancel_and_close()
         else
           // SSLRequired or unexpected: silently give up
@@ -79,8 +79,9 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
     end
 
   fun ref _on_tls_ready() =>
-    // Reset expect from 1 back to 0 (same pattern as _SessionSSLNegotiating)
-    _tcp_connection.expect(None)
+    // Reset buffer_until from 1 to streaming (same pattern as
+    // _SessionSSLNegotiating)
+    _tcp_connection.buffer_until(lori.Streaming)
     _send_cancel_and_close()
 
   fun ref _on_tls_failure(reason: lori.TLSFailureReason) =>

--- a/postgres/connection_failure_reason.pony
+++ b/postgres/connection_failure_reason.pony
@@ -23,6 +23,13 @@ primitive TLSHandshakeFailed
   The TLS handshake failed.
   """
 
+primitive ConnectionFailedTimeout
+  """
+  The connection attempt timed out before a TCP or TLS connection was
+  established.
+  """
+
 type ConnectionFailureReason is
   (ConnectionFailedDNS | ConnectionFailedTCP |
-   SSLServerRefused | TLSAuthFailed | TLSHandshakeFailed)
+   SSLServerRefused | TLSAuthFailed | TLSHandshakeFailed |
+   ConnectionFailedTimeout)

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -184,6 +184,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     | let _: lori.ConnectionFailedDNS => ConnectionFailedDNS
     | let _: lori.ConnectionFailedTCP => ConnectionFailedTCP
     | let _: lori.ConnectionFailedSSL => TLSHandshakeFailed
+    | let _: lori.ConnectionFailedTimeout => ConnectionFailedTimeout
     end
     state.on_failure(this, r)
 
@@ -393,11 +394,11 @@ class ref _SessionSSLNegotiating
     _proceed_to_connected(s)
 
   fun ref _proceed_to_connected(s: Session ref) =>
-    // Reset expect from 1 (set during SSLRequest) to 0 (deliver all available
-    // bytes). Critical: lori preserves the expect(1) value across start_tls()
-    // via _ssl_expect. Without this reset, decrypted data would be delivered
+    // Reset buffer_until from 1 (set during SSLRequest) to streaming (deliver
+    // all available bytes). Critical: lori preserves the buffer_until value
+    // across start_tls(). Without this reset, decrypted data would be delivered
     // 1 byte at a time, breaking _ResponseParser.
-    s._connection().expect(None)
+    s._connection().buffer_until(lori.Streaming)
     s.state = _SessionConnected(_notify, _database_connect_info,
       _codec_registry)
     _notify.pg_session_connected(s)
@@ -2651,12 +2652,12 @@ trait _ConnectableState is _UnconnectedState
   fun _start_ssl_negotiation(s: Session ref, ctx: SSLContext val,
     fallback_on_refusal: Bool)
   =>
-    // Set expect(1) BEFORE sending SSLRequest so lori delivers exactly
+    // Set buffer_until(1) BEFORE sending SSLRequest so lori delivers exactly
     // one byte per _on_received call. Any MITM-injected bytes stay in
     // lori's internal buffer, causing start_tls() to return
     // StartTLSNotReady (CVE-2021-23222 mitigation).
-    match \exhaustive\ lori.MakeExpect(1)
-    | let e: lori.Expect => s._connection().expect(e)
+    match \exhaustive\ lori.MakeBufferSize(1)
+    | let e: lori.BufferSize => s._connection().buffer_until(e)
     else
       _Unreachable()
     end


### PR DESCRIPTION
Upgrades lori from 0.11.0 to 0.12.0 and fixes a stale ssl version reference in CLAUDE.md (2.0.0 → 2.0.1, left behind by #176).

Lori 0.12.0 renames `expect()` to `buffer_until()` (with `Expect` → `BufferSize`, `None` → `Streaming`, `MakeExpect` → `MakeBufferSize`) and adds `ConnectionFailedTimeout` to `ConnectionFailureReason`. We pass the new variant through to our own `ConnectionFailureReason` union so users can match on it.