### PR TITLE
Fix crash when closing a Session before connection initialization completes

### DIFF
--- a/.release-notes/fix-dispose-before-init-crash.md
+++ b/.release-notes/fix-dispose-before-init-crash.md
@@ -1,0 +1,3 @@
+## Fix crash when closing a Session before connection initialization completes
+
+Closing a `Session` immediately after creating it could crash if the close message arrived before the underlying connection actor finished its internal initialization. This was a race condition between Pony's causal messaging guarantees — the initialization message (self-to-self) and the close message (external sender) have no ordering guarantee. The race was unlikely but was observed on macOS arm64.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 2.0.1 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.12.0 (TCP networking, STARTTLS support)
+- `ponylang/lori` 0.13.0 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
    {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.12.0"
+      "version": "0.13.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Closing a `Session` immediately after creating it could crash if the close message arrived before the underlying connection actor finished its internal initialization. This was a race condition between Pony's causal messaging guarantees — the initialization message (self-to-self) and the close message (external sender) have no ordering guarantee. The race was unlikely but was observed on macOS arm64.

Updates lori to 0.13.0.