### PR TITLE
Update lori to 0.14.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,12 @@
+
+## Fix potential connection hang when timer event subscription fails
+
+On some platforms, if the operating system cannot allocate resources for a connection timer (e.g., ENOMEM on kqueue or epoll), connections could hang silently instead of reporting an error. Timer subscription failures are now detected and reported as connection failures.
+
+## Add ConnectionFailedTimerError to ConnectionFailureReason
+
+`ConnectionFailureReason` now includes `ConnectionFailedTimerError`, which is reported when the connect timer's ASIO event subscription fails. If you match exhaustively on `ConnectionFailureReason`, you'll need to add a handler for the new variant.
+
+## Require ponyc 0.63.1 or later
+
+postgres now requires ponyc 0.63.1 or later. Older ponyc versions are no longer supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix potential connection hang when timer event subscription fails ([PR #202](https://github.com/ponylang/postgres/pull/202))
 
 ### Added
 
 
 ### Changed
 
+- Add ConnectionFailedTimerError to ConnectionFailureReason ([PR #202](https://github.com/ponylang/postgres/pull/202))
+- Require ponyc 0.63.1 or later ([PR #202](https://github.com/ponylang/postgres/pull/202))
 
 ## [0.3.1] - 2026-04-07
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ postgres is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
+* Requires ponyc 0.63.1 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/postgres.git --version 0.3.1`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.13.1"
+      "version": "0.14.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/postgres/connection_failure_reason.pony
+++ b/postgres/connection_failure_reason.pony
@@ -29,7 +29,13 @@ primitive ConnectionFailedTimeout
   established.
   """
 
+primitive ConnectionFailedTimerError
+  """
+  The connection was aborted because the connect timer's ASIO event
+  subscription failed.
+  """
+
 type ConnectionFailureReason is
   (ConnectionFailedDNS | ConnectionFailedTCP |
    SSLServerRefused | TLSAuthFailed | TLSHandshakeFailed |
-   ConnectionFailedTimeout)
+   ConnectionFailedTimeout | ConnectionFailedTimerError)

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -223,6 +223,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     | let _: lori.ConnectionFailedTCP => ConnectionFailedTCP
     | let _: lori.ConnectionFailedSSL => TLSHandshakeFailed
     | let _: lori.ConnectionFailedTimeout => ConnectionFailedTimeout
+    | let _: lori.ConnectionFailedTimerError => ConnectionFailedTimerError
     end
     state.on_failure(this, r)
 


### PR DESCRIPTION
Picks up ASIO_ERROR handling for timer subscription failures, adds ConnectionFailedTimerError to ConnectionFailureReason, and requires ponyc 0.63.1 or later.