### PR TITLE
Guard against integer underflow on server-supplied message lengths

### DIFF
--- a/.release-notes/reject-short-length-fields.md
+++ b/.release-notes/reject-short-length-fields.md
@@ -1,0 +1,3 @@
+## Guard against integer underflow on server-supplied message lengths
+
+When a PostgreSQL server declared a message length smaller than the protocol's minimum, the driver performed an unsigned subtraction that wrapped to a huge value. The full consequences of the wrap were not fully characterized — one observed effect was silently consuming malformed bytes as a zero-payload acknowledgement before eventually reporting a protocol violation, but other downstream effects may have been reachable with different message shapes. The driver now validates length fields before arithmetic and rejects such messages as a protocol violation immediately.

--- a/postgres/_response_parser.pony
+++ b/postgres/_response_parser.pony
@@ -72,8 +72,9 @@ primitive _ResponseParser
 
     // postgres sends the payload size as the payload plus the 4 bytes for the
     // descriptive header on the payload. We are calling `payload_size` to be
-    // only the payload, not the header as well.
-    let payload_size = buffer.peek_u32_be(1)?.usize() - 4
+    // only the payload, not the header as well. `sub_partial` errors on a
+    // server-declared length less than 4 instead of wrapping the result.
+    let payload_size = buffer.peek_u32_be(1)?.usize().sub_partial(4)?
     let message_size = payload_size + 4 + 1
 
     // The message will be `message_size` in length. If we have less than
@@ -111,7 +112,7 @@ primitive _ResponseParser
         buffer.skip(9)?
         // Parse null-terminated mechanism names from the remaining payload.
         // The list ends with a lone null byte (empty string).
-        let remaining = payload_size - 4
+        let remaining = payload_size.sub_partial(4)?
         let payload = buffer.block(remaining)?
         let reader: Reader = Reader.>append(consume payload)
         let mechanisms: Array[String] iso = recover iso Array[String] end
@@ -126,13 +127,13 @@ primitive _ResponseParser
       elseif auth_type == _AuthenticationRequestType.sasl_continue() then
         // Skip past header (5 bytes) and auth type field (4 bytes)
         buffer.skip(9)?
-        let remaining = payload_size - 4
+        let remaining = payload_size.sub_partial(4)?
         let data = buffer.block(remaining)?
         return _AuthenticationSASLContinueMessage(consume data)
       elseif auth_type == _AuthenticationRequestType.sasl_final() then
         // Skip past header (5 bytes) and auth type field (4 bytes)
         buffer.skip(9)?
-        let remaining = payload_size - 4
+        let remaining = payload_size.sub_partial(4)?
         let data = buffer.block(remaining)?
         return _AuthenticationSASLFinalMessage(consume data)
       else
@@ -154,7 +155,7 @@ primitive _ResponseParser
       // Slide past the header...
       buffer.skip(5)?
       // and only get the payload
-      let payload = buffer.block(payload_size - 1)?
+      let payload = buffer.block(payload_size.sub_partial(1)?)?
       // And skip the null terminator
       buffer.skip(1)?
       return _command_complete(consume payload)?

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -57,6 +57,7 @@ actor \nodoc\ Main is TestList
     test(_TestResponseParserReadyForQueryMessage)
     test(_TestResponseParserRowDescriptionMessage)
     test(_TestResponseParserRowDescriptionBinaryFormat)
+    test(_TestResponseParserShortLengthField)
     test(_TestResponseParserParseCompleteMessage)
     test(_TestResponseParserBindCompleteMessage)
     test(_TestResponseParserNoDataMessage)

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -56,6 +56,32 @@ class \nodoc\ iso _TestResponseParserJunkMessage is UnitTest
       r.append(bytes)
       _ResponseParser(r)? })
 
+class \nodoc\ iso _TestResponseParserShortLengthField is UnitTest
+  """
+  Verify that a server-declared payload length less than 4 causes the parser
+  to error rather than silently consume malformed bytes as a zero-payload
+  acknowledgement. A length of 4 means a zero-byte payload and is still
+  valid on the wire — covered by `_TestResponseParserParseCompleteMessage`.
+  """
+  fun name(): String =>
+    "ResponseParser/ShortLengthField"
+
+  fun apply(h: TestHelper) =>
+    for declared_length in [as U8: 0; 1; 2; 3].values() do
+      let len' = declared_length
+      // Type byte '1' (ParseComplete) is used because without the bounds
+      // check, both `payload_size` and `message_size` wrap such that
+      // `buffer.skip(message_size)` succeeds on a 5-byte buffer and returns
+      // a bogus success — the strongest counterfactual for the fix.
+      h.assert_error(
+        {()(len') ? =>
+          let bytes: Array[U8] val = [as U8: '1'; 0; 0; 0; len']
+          let r: Reader = Reader
+          r.append(bytes)
+          _ResponseParser(r)? },
+        "length=" + declared_length.string() + " should error")
+    end
+
 class \nodoc\ iso _TestResponseParserAuthenticationOkMessage is UnitTest
   """
   Verify that AuthenticationOk messages are parsed correctly


### PR DESCRIPTION
Closes #211.

USize subtraction wraps. Bare `payload_size - N` arithmetic on server-declared lengths could produce huge values with consequences that aren't fully characterized — validate at the arithmetic site so the wrap surfaces as a protocol violation directly.