### PR TITLE
Guard against integer overflow on server-supplied message lengths

### DIFF
--- a/.release-notes/guard-message-size-wrap.md
+++ b/.release-notes/guard-message-size-wrap.md
@@ -1,0 +1,3 @@
+## Guard against integer overflow on server-supplied message lengths
+
+On 32-bit platforms, a PostgreSQL server that declared a message length near `U32.max` could wrap the driver's internal size calculation to a small value (including 0). The buffer-size check then passed incorrectly and the parser could return a phantom acknowledgement message — a bogus success. The driver now validates the size arithmetic and rejects such messages as a protocol violation immediately. 64-bit platforms were not affected.

--- a/postgres/_response_parser.pony
+++ b/postgres/_response_parser.pony
@@ -74,8 +74,12 @@ primitive _ResponseParser
     // descriptive header on the payload. We are calling `payload_size` to be
     // only the payload, not the header as well. `sub_partial` errors on a
     // server-declared length less than 4 instead of wrapping the result.
+    // The `add_partial` chain guards the reverse direction: on 32-bit USize
+    // targets, adding back the 4-byte length header and the 1-byte type tag
+    // could wrap a near-`U32.max` declared length down to a small value and
+    // let bogus "complete" messages slip past the buffer-size check.
     let payload_size = buffer.peek_u32_be(1)?.usize().sub_partial(4)?
-    let message_size = payload_size + 4 + 1
+    let message_size = payload_size.add_partial(4)?.add_partial(1)?
 
     // The message will be `message_size` in length. If we have less than
     // that then there's no point in continuing.

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -73,6 +73,7 @@ actor \nodoc\ Main is TestList
     test(_TestResponseParserRowDescriptionMessage)
     test(_TestResponseParserRowDescriptionBinaryFormat)
     test(_TestResponseParserShortLengthField)
+    test(_TestResponseParserLongLengthField)
     test(_TestResponseParserParseCompleteMessage)
     test(_TestResponseParserBindCompleteMessage)
     test(_TestResponseParserNoDataMessage)

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -82,6 +82,49 @@ class \nodoc\ iso _TestResponseParserShortLengthField is UnitTest
         "length=" + declared_length.string() + " should error")
     end
 
+class \nodoc\ iso _TestResponseParserLongLengthField is UnitTest
+  """
+  Verify that a server-declared payload length near `U32.max` cannot wrap
+  `message_size` on 32-bit `USize` targets. Without the `add_partial`
+  guard, `payload_size + 4 + 1` would wrap `U32.max` down to 0 on ilp32;
+  `buffer.skip(0)` would then succeed on a 5-byte buffer and return a
+  phantom `_ParseCompleteMessage`.
+
+  CI runs lp64, so the ilp32 branch of the assertion cannot be exercised
+  here. It is retained so the regression is caught when a Pony build
+  eventually runs on a 32-bit target.
+  """
+  fun name(): String =>
+    "ResponseParser/LongLengthField"
+
+  fun apply(h: TestHelper) =>
+    // Type byte '1' (ParseComplete) mirrors the `ShortLengthField`
+    // counterfactual — the strongest regression signal on 32-bit.
+    let bytes: Array[U8] val =
+      [as U8: '1'; 0xFF; 0xFF; 0xFF; 0xFF]
+    ifdef ilp32 then
+      h.assert_error(
+        {() ? =>
+          let r: Reader = Reader
+          r.append(bytes)
+          _ResponseParser(r)? },
+        "U32.max length should error on ilp32 (message_size wrap)")
+    else
+      try
+        let r: Reader = Reader
+        r.append(bytes)
+        match _ResponseParser(r)?
+        | None => None
+        else
+          h.fail(
+            "Parser returned a message for a buffer smaller than the " +
+            "declared length.")
+        end
+      else
+        h.fail("Parser errored unexpectedly on lp64.")
+      end
+    end
+
 class \nodoc\ iso _TestResponseParserAuthenticationOkMessage is UnitTest
   """
   Verify that AuthenticationOk messages are parsed correctly


### PR DESCRIPTION
Companion to #211. On 32-bit `USize` targets a server-declared length near `U32.max` could wrap `payload_size + 4 + 1` to a small value, slipping a bogus zero-payload acknowledgement past the buffer-size check. The fix is the same flavor as #215 — use partial arithmetic at the site so the wrap surfaces as a protocol violation directly.

CI runs lp64, so the new test's ilp32 branch can't be exercised here; the counterfactual was walked through analytically and is documented in the test's docstring.

Closes #217.