### PR TITLE
Assert SSLServerRefused in SSL negotiation refusal test

### DIFF
--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -43,7 +43,13 @@ actor \nodoc\ _SSLRefusedTestNotify is SessionStatusNotify
   be pg_session_connection_failed(s: Session,
     reason: ConnectionFailureReason)
   =>
-    _connection_failed = true
+    match reason
+    | SSLServerRefused =>
+      _connection_failed = true
+    else
+      _h.fail("Expected SSLServerRefused.")
+      _h.complete(false)
+    end
 
   be pg_session_connected(s: Session) =>
     _h.fail("Should not have connected")


### PR DESCRIPTION
Tightens `_SSLRefusedTestNotify` to match specifically on `SSLServerRefused` instead of accepting any `ConnectionFailureReason`, mirroring the pattern already used by `_SSLJunkTestNotify` in the same file.

Closes #213