### PR TITLE
Validate DataRow column length before buffered read

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -120,6 +120,10 @@ The same applies to `ClientQueryError`: add a `| ProtocolViolation =>` arm to an
 
 When a PostgreSQL server declared a message length smaller than the protocol's minimum, the driver performed an unsigned subtraction that wrapped to a huge value. The full consequences of the wrap were not fully characterized — one observed effect was silently consuming malformed bytes as a zero-payload acknowledgement before eventually reporting a protocol violation, but other downstream effects may have been reachable with different message shapes. The driver now validates length fields before arithmetic and rejects such messages as a protocol violation immediately.
 
+## Guard against malformed column lengths in data rows
+
+When a PostgreSQL server declared a DataRow column length whose sign bit was set (other than the -1 NULL marker), the driver passed the value through to a buffered read without validating it. PostgreSQL declares column length as a signed Int32, so values in that range are protocol violations. The full consequences were not fully characterized — the bogus length triggered a downstream read failure that surfaced as a protocol violation, but the validation was incidental rather than explicit. The driver now validates column lengths at the parse site and rejects such messages as a protocol violation immediately.
+
 ## Detect peer-initiated TCP close during any session state
 
 If the server closed the TCP connection at any point — during SSL negotiation, pre-auth startup, mid-SCRAM, or after the session reached the ready state — the driver would hang indefinitely without notifying the application. Peer close is now detected and delivered through the state machine's own error handling.

--- a/postgres/_response_parser.pony
+++ b/postgres/_response_parser.pony
@@ -326,6 +326,12 @@ primitive _ResponseParser
       | 0 =>
         columns.push(recover val Array[U8] end)
       else
+        // PostgreSQL declares column length as a signed Int32, so values
+        // with the sign bit set (other than the -1 NULL marker handled
+        // above) are protocol violations. Validating here surfaces the
+        // bogus length as an explicit error rather than letting it
+        // silently propagate into the buffered read.
+        if column_length > I32.max_value().u32() then error end
         let column = reader.block(column_length.usize())?
         columns.push(consume column)
       end

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -60,6 +60,7 @@ actor \nodoc\ Main is TestList
     test(_TestResponseParserAuthenticationMD5PasswordMessage)
     test(_TestResponseParserAuthenticationOkMessage)
     test(_TestResponseParserCommandCompleteMessage)
+    test(_TestResponseParserDataRowBogusColumnLength)
     test(_TestResponseParserDataRowMessage)
     test(_TestResponseParserEmptyBuffer)
     test(_TestResponseParserEmptyQueryResponseMessage)

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -524,6 +524,35 @@ class \nodoc\ iso _TestResponseParserDataRowMessage is UnitTest
       h.fail("Wrong message returned.")
     end
 
+class \nodoc\ iso _TestResponseParserDataRowBogusColumnLength is UnitTest
+  """
+  Verify that a DataRow column length whose sign bit is set (other than the
+  -1 NULL marker) errors at the validation site rather than silently
+  propagating the bogus length into the buffered read. PostgreSQL declares
+  column length as a signed Int32, so 0x80000000 through 0xFFFFFFFE are
+  protocol violations.
+  """
+  fun name(): String =>
+    "ResponseParser/DataRowBogusColumnLength"
+
+  fun apply(h: TestHelper) =>
+    for column_length in [as U32: 0x80000000; 0xFFFFFFFE].values() do
+      let cl = column_length
+      h.assert_error(
+        {()(cl) ? =>
+          let wb: Writer = Writer
+          wb.u8(_MessageType.data_row())
+          // payload size: 4 (header) + 2 (num cols) + 4 (column length)
+          wb.u32_be(10)
+          wb.u16_be(1)
+          wb.u32_be(cl)
+          let bytes = WriterToByteArray(wb)
+          let r: Reader = Reader
+          r.append(bytes)
+          _ResponseParser(r)? },
+        "column_length=" + cl.string() + " should error")
+    end
+
 class \nodoc\ val _IncomingAuthenticationOkTestMessage
     let _bytes: Array[U8] val
 


### PR DESCRIPTION
Closes #216.

`_data_row` matched the column length against `-1` (NULL) and `0`, but column lengths in `0x80000000..0xFFFFFFFE` — invalid signed `Int32` values — fell through to `reader.block()` without validation. The huge length errored at the buffered read and routed through the protocol-violation path, so no observable behavior changes; this makes the validation explicit at the parse site. Same flavor as #211.

Note on the test: both code paths (with and without the explicit `if`) error externally — `reader.block()` will reject any bogus length we can practically construct in a test. The test is therefore a behavioral regression test for "parser rejects malformed column length", not a strict counterfactual for the new `if`. Flagging in case you'd rather drop the test — I think keeping it is the right call but it's a judgment call.