### PR TITLE
Require ponyc 0.64.0 or later

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     services:
       postgres:
         image: postgres:14.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.release-notes/require-ponyc-0.64.0.md
+++ b/.release-notes/require-ponyc-0.64.0.md
@@ -1,0 +1,5 @@
+## Require ponyc 0.64.0 or later
+
+postgres now requires ponyc 0.64.0 or later. The previous minimum was 0.63.1.
+
+This is driven by an update to lori 0.15.0, which requires ponyc 0.64.0 for changes to FFI declaration syntax and the runtime socket API. Older ponyc versions will fail to compile postgres.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 2.0.1 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.14.1 (TCP networking, STARTTLS support)
+- `ponylang/lori` 0.15.0 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ postgres is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.63.1 or later
+* Requires ponyc 0.64.0 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/postgres.git --version 0.5.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.14.1"
+      "version": "0.15.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates postgres to use lori 0.15.0, which requires ponyc 0.64.0 or later. Switches CI workflows that pull `shared-docker-ci-standard-builder-with-libressl-4.2.1` and `library-documentation-action-v2` from the `:release` channel to `:nightly` so they can build against the soon-to-be-released ponyc 0.64.0.

Will need a follow-up to switch back to `:release` once ponyc 0.64.0 ships (tracked in ponylang/ponyc#5298).