### PR TITLE
Fix connection hang after sending a large amount of data

### DIFF
--- a/.release-notes/fix-silent-connection-after-large-send.md
+++ b/.release-notes/fix-silent-connection-after-large-send.md
@@ -1,0 +1,3 @@
+## Fix connection hang after sending a large amount of data
+
+After sending a large query or a large amount of data, a connection could stop receiving the server's responses — an in-flight query would never complete and the connection would hang. No error was raised and the connection was not closed; it simply went quiet, even though the server had already replied. This most often showed up with large statements or bulk data. Responses now arrive as expected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 2.0.1 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.15.0 (TCP networking, STARTTLS support)
+- `ponylang/lori` 0.15.1 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.0"
+      "version": "0.15.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.15.1, which fixes a connection that could go silent after a large send drained under backpressure, leaving the server's responses undelivered.