### PR TITLE
Drop support for Windows 10

### DIFF
--- a/.release-notes/drop-windows-10-support.md
+++ b/.release-notes/drop-windows-10-support.md
@@ -1,0 +1,3 @@
+## Drop support for Windows 10
+
+Building postgres for Windows now requires ponyc 0.66.0 or later and Windows 11 or Windows Server 2022 or later. Windows 10 is no longer supported. Non-Windows platforms are unaffected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 2.0.1 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.15.1 (TCP networking, STARTTLS support)
+- `ponylang/lori` 0.16.0 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.1"
+      "version": "0.16.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.16.0, which moves Windows networking from IOCP to readiness notifications.

On Windows this drops support for Windows 10 — the floor is now Windows 11 / Windows Server 2022 — and building for Windows now requires ponyc 0.66.0 or later. Non-Windows platforms are unaffected.