### PR TITLE
Update lori to 0.16.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ SSL version is mandatory. Tests run with `--sequential`. Integration tests requi
 ## Dependencies
 
 - `ponylang/ssl` 2.0.1 (MD5 password hashing, SCRAM-SHA-256 crypto primitives via `ssl/crypto`, SSL/TLS via `ssl/net`)
-- `ponylang/lori` 0.16.0 (TCP networking, STARTTLS support)
+- `ponylang/lori` 0.16.1 (TCP networking, STARTTLS support)
 
 Managed via `corral`.
 

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.0"
+      "version": "0.16.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.16.1. postgres does not use lori's idle timeout, so the 0.16.1 idle-timer fix has no user-facing effect here — this is a maintenance bump to stay current.