### PR TITLE
Update lori to 0.17.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,37 @@
+## Fix session close dropping queued writes
+
+When a session hands the socket more bytes than it will take at once, the rest is queued until the socket drains. `Session.close()` discarded that queue — the bytes never reached the server, even though the session was closed cleanly rather than aborted.
+
+`Session.close()` now writes out what is still queued before shutting the session down.
+
+## Fix a hang when closing a session while handling a server message
+
+postgres closes a session from inside its handling of a message that just arrived: when the server sends something that violates the protocol, and when a connection attempt fails after the server has already replied. Closing there could leave the session attempting one more read on the socket it had just closed. In a program that opens and closes many sessions, that stray read could block one of the runtime's scheduler threads and keep the program from exiting.
+
+A session no longer attempts that read after closing.
+
+## Fix a possible write hang under load
+
+Under write load, a write on a session's socket could stall and never return, stopping the whole program. The stall needed a blocking file descriptor, and sessions use non-blocking ones, so it was only reachable once the operating system had reused a closed connection's descriptor number for a blocking socket somewhere else in the same process — rare, but possible.
+
+Writes no longer hang on Linux, FreeBSD, OpenBSD, and DragonFly. macOS and Windows are unchanged.
+
+## Require ponyc 0.67.0 or later
+
+postgres now requires ponyc 0.67.0 or later on every platform. The previous minimum was 0.64.0, and 0.66.0 on Windows; 0.64.0 through 0.66.x are no longer supported. The write hang under load is closed by a socket call that ponyc added in 0.67.0.
+
+## Move to ponylang/ssl 3.0.0
+
+postgres now depends on ponylang/ssl 3.0.0, where it depended on 2.0.1. Nothing in postgres's own API changed — you still build an `SSLContext val` and hand it to `SSLRequired` or `SSLPreferred`. If your application does not declare ssl itself, it picks up 3.0.0 through postgres, and your own `use "ssl/net"` or `use "ssl/crypto"` code is built against it. If your application does declare ssl, your declaration is the one that applies.
+
+The one most likely to reach you is a rename. The twelve protocol-version primitives now spell their acronyms in full, and those are the values passed to `SSLContext.set_min_proto_version` and `set_max_proto_version` — so pinning a minimum TLS version on the context you hand postgres needs an edit.
+
+```pony
+// Before
+ctx.set_min_proto_version(Tls1u2Version())?
+
+// After
+ctx.set_min_proto_version(TLS1u2Version())?
+```
+
+The rest of the breaking changes: constructing a `Digest`, `Digest.final`, and `HmacSha256` are now partial and need a `?`; `SSLContext.alpn_set_resolver` takes an `ALPNProtocolResolver val` where it took a `box`; `SSLState` gained an `SSLDisposed` member, which breaks an exhaustive match on `SSL.state()`; and a reference typed `HashFn tag` no longer compiles, so type it `val` or `box`. See ponylang/ssl's own 3.0.0 release notes for the details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ make start-pg-containers           # start the test PostgreSQL containers
 make stop-pg-containers            # stop them
 ```
 
-`ssl=` is required (for example `ssl=3.0.x` for OpenSSL 3.x). Tests run `--sequential`.
+`ssl=` is required, set to your installed TLS library: `4.0.x`, `3.0.x`, `1.1.x`, or `libressl`. Tests run `--sequential`.
 
 Integration tests need two PostgreSQL 14.5 containers, started by `make start-pg-containers`: a plaintext one on port 5432 (SCRAM-SHA-256 default auth) and an SSL one on port 5433. Connection parameters come from the `POSTGRES_*` environment variables read by `_ConnectionTestConfiguration` in `_test.pony`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix session close dropping queued writes ([PR #241](https://github.com/ponylang/postgres/pull/241))
+- Fix a hang when closing a session while handling a server message ([PR #241](https://github.com/ponylang/postgres/pull/241))
+- Fix a possible write hang under load ([PR #241](https://github.com/ponylang/postgres/pull/241))
+
 
 ### Added
 
 
+
 ### Changed
+
+- Require ponyc 0.67.0 or later ([PR #241](https://github.com/ponylang/postgres/pull/241))
+- Move to ponylang/ssl 3.0.0 ([PR #241](https://github.com/ponylang/postgres/pull/241))
 
 
 ## [0.7.0] - 2026-06-29

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean start-pg-containers stop-pg-containers TAGS))
-  ifeq ($(ssl), 3.0.x)
+  ifeq ($(ssl), 4.0.x)
+          SSL = -Dopenssl_4.0.x
+  else ifeq ($(ssl), 3.0.x)
           SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
           SSL = -Dopenssl_1.1.x

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ postgres is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later.
+* Requires ponyc 0.67.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/postgres.git --version 0.7.0`
 * `corral fetch` to fetch your dependencies
 * `use "postgres"` to include this package
 * `corral run -- ponyc` to compile your application
 
-This library has a transitive dependency on [ponylang/ssl](https://github.com/ponylang/ssl). It requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl?tab=readme-ov-file#installation) for more information.
+This library depends on [ponylang/ssl](https://github.com/ponylang/ssl). It requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl?tab=readme-ov-file#installation) for more information.
 
 ## API Documentation
 

--- a/corral.json
+++ b/corral.json
@@ -5,11 +5,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.1"
+      "version": "0.17.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.1"
+      "version": "3.0.0"
     }
   ],
   "info": {

--- a/postgres/_cancel_sender.pony
+++ b/postgres/_cancel_sender.pony
@@ -45,7 +45,7 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
       _tcp_connection.send(_FrontendMessage.ssl_request())
     end
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     // Only called during SSL negotiation — server responds 'S' or 'N'.
     try
       if data(0)? == 'S' then
@@ -54,7 +54,7 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
         | let pref: SSLPreferred => pref.ctx
         else
           _tcp_connection.close()
-          return
+          return lori.KeepReading
         end
         match \exhaustive\ _tcp_connection.start_tls(ctx, _info.host)
         | None => None  // Handshake started, wait for _on_tls_ready
@@ -77,6 +77,7 @@ actor _CancelSender is (lori.TCPConnectionActor & lori.ClientLifecycleEventRecei
     else
       _tcp_connection.close()
     end
+    lori.KeepReading
 
   fun ref _on_tls_ready() =>
     // Reset buffer_until from 1 to streaming (same pattern as

--- a/postgres/_scram_sha256.pony
+++ b/postgres/_scram_sha256.pony
@@ -44,8 +44,8 @@ primitive _ScramSha256
     """
     Compute the SCRAM client proof and server signature.
 
-    Returns `(client_proof, server_signature)`. Partial because PBKDF2 can
-    fail (e.g., zero iterations).
+    Returns `(client_proof, server_signature)`. Raises when the PBKDF2 or
+    HMAC computation fails.
 
     The computation follows RFC 5802 Section 3:
     1. SaltedPassword = PBKDF2(password, salt, iterations, 32)
@@ -59,13 +59,13 @@ primitive _ScramSha256
     8. ServerSignature = HMAC(ServerKey, AuthMessage)
     """
     let salted_password = Pbkdf2Sha256(password, salt, iterations, 32)?
-    let client_key = HmacSha256(salted_password, "Client Key")
+    let client_key = HmacSha256(salted_password, "Client Key")?
     let stored_key = SHA256(client_key)
     let auth_message: String val = recover val
       client_first_bare + "," + server_first + ","
         + client_final_message_without_proof(combined_nonce)
     end
-    let client_signature = HmacSha256(stored_key, auth_message)
+    let client_signature = HmacSha256(stored_key, auth_message)?
 
     // ClientProof = ClientKey XOR ClientSignature
     let client_proof = recover iso
@@ -82,7 +82,7 @@ primitive _ScramSha256
       proof
     end
 
-    let server_key = HmacSha256(salted_password, "Server Key")
-    let server_signature: Array[U8] val = HmacSha256(server_key, auth_message)
+    let server_key = HmacSha256(salted_password, "Server Key")?
+    let server_signature: Array[U8] val = HmacSha256(server_key, auth_message)?
 
     (consume client_proof, server_signature)

--- a/postgres/_test_auth.pony
+++ b/postgres/_test_auth.pony
@@ -310,12 +310,13 @@ actor \nodoc\ _UnsupportedAuthenticationTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if not _received then
       _received = true
       let msg = _IncomingUnsupportedAuthenticationTestMessage(2).bytes()
       _tcp_connection.send(msg)
     end
+    lori.KeepReading
 
 // Cleartext password authentication tests
 
@@ -435,9 +436,10 @@ actor \nodoc\ _CleartextTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -624,9 +626,10 @@ actor \nodoc\ _SCRAMTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -735,7 +738,7 @@ actor \nodoc\ _SCRAMUnsupportedTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if not _authed then
       _authed = true
       let mechanisms: Array[String] val =
@@ -743,6 +746,7 @@ actor \nodoc\ _SCRAMUnsupportedTestServer
       let sasl = _IncomingAuthenticationSASLTestMessage(mechanisms).bytes()
       _tcp_connection.send(sasl)
     end
+    lori.KeepReading
 
 actor \nodoc\ _SCRAMErrorTestListener is lori.TCPListenerActor
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
@@ -797,9 +801,10 @@ actor \nodoc\ _SCRAMErrorTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -882,9 +887,10 @@ actor \nodoc\ _SCRAMSkipSASLFinalTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -989,9 +995,10 @@ actor \nodoc\ _SCRAMDuplicateSASLContinueTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1085,9 +1092,10 @@ actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1173,9 +1181,10 @@ actor \nodoc\ _SCRAMMalformedSASLFinalTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1270,9 +1279,10 @@ actor \nodoc\ _SCRAMNonceMismatchTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1361,9 +1371,10 @@ actor \nodoc\ _SCRAMMalformedSASLContinueTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1659,7 +1670,7 @@ actor \nodoc\ _TooManyConnectionsTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if not _sent then
       match _reader.read_startup_message()
@@ -1672,6 +1683,7 @@ actor \nodoc\ _TooManyConnectionsTestServer
         _tcp_connection.close()
       end
     end
+    lori.KeepReading
 
 actor \nodoc\ _TooManyConnectionsTestNotify is SessionStatusNotify
   let _h: TestHelper

--- a/postgres/_test_auth_requirement.pony
+++ b/postgres/_test_auth_requirement.pony
@@ -172,9 +172,10 @@ actor \nodoc\ _AuthMethodRejectedTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then

--- a/postgres/_test_cancel.pony
+++ b/postgres/_test_cancel.pony
@@ -112,9 +112,10 @@ actor \nodoc\ _CancelTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _is_cancel_connection then
@@ -307,9 +308,10 @@ actor \nodoc\ _SSLCancelTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _ssl_started then

--- a/postgres/_test_connection_closed.pony
+++ b/postgres/_test_connection_closed.pony
@@ -114,14 +114,15 @@ actor \nodoc\ _RemoteCloseAfterSSLRequestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
-    if _closed then return end
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    if _closed then return lori.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
       _closed = true
       _tcp_connection.close()
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestRemoteClosePreAuth is UnitTest
   """
@@ -220,14 +221,15 @@ actor \nodoc\ _RemoteCloseAfterStartupServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
-    if _closed then return end
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    if _closed then return lori.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
       _closed = true
       _tcp_connection.close()
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseSCRAM is UnitTest
   """
@@ -328,7 +330,7 @@ actor \nodoc\ _RemoteCloseSCRAMServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if _phase == 0 then
       match _reader.read_startup_message()
@@ -346,6 +348,7 @@ actor \nodoc\ _RemoteCloseSCRAMServer
         _tcp_connection.close()
       end
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseLoggedInIdle is UnitTest
   """
@@ -440,8 +443,8 @@ actor \nodoc\ _RemoteCloseLoggedInIdleServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
-    if _closed then return end
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    if _closed then return lori.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -450,6 +453,7 @@ actor \nodoc\ _RemoteCloseLoggedInIdleServer
       _tcp_connection.send(_IncomingReadyForQueryTestMessage('I').bytes())
       _tcp_connection.close()
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseLoggedInInFlight is UnitTest
   """
@@ -574,7 +578,7 @@ actor \nodoc\ _RemoteCloseAfterQueryServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -589,6 +593,7 @@ actor \nodoc\ _RemoteCloseAfterQueryServer
         _tcp_connection.close()
       end
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseLoggedInPipeline is UnitTest
   """
@@ -1280,8 +1285,8 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
-    if _closed then return end
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    if _closed then return lori.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -1289,6 +1294,7 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyServer
       _tcp_connection.send(_IncomingAuthenticationOkTestMessage.bytes())
       _tcp_connection.close()
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseCloseStatementInFlight is UnitTest
   """
@@ -1502,8 +1508,8 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
-    if _closed then return end
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    if _closed then return lori.KeepReading end
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -1522,6 +1528,7 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseServer
         _tcp_connection.close()
       end
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseSSLNegotiatingPreferred is UnitTest
   """

--- a/postgres/_test_copy_in.pony
+++ b/postgres/_test_copy_in.pony
@@ -128,9 +128,10 @@ actor \nodoc\ _CopyInSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -287,9 +288,10 @@ actor \nodoc\ _CopyInAbortTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -461,9 +463,10 @@ actor \nodoc\ _CopyInServerErrorTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then

--- a/postgres/_test_copy_out.pony
+++ b/postgres/_test_copy_out.pony
@@ -121,9 +121,10 @@ actor \nodoc\ _CopyOutSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -280,9 +281,10 @@ actor \nodoc\ _CopyOutEmptyTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -442,9 +444,10 @@ actor \nodoc\ _CopyOutServerErrorTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then

--- a/postgres/_test_notice.pony
+++ b/postgres/_test_notice.pony
@@ -237,9 +237,10 @@ actor \nodoc\ _NoticeTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -326,9 +327,10 @@ actor \nodoc\ _NoticeMidQueryTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then

--- a/postgres/_test_notification.pony
+++ b/postgres/_test_notification.pony
@@ -238,9 +238,10 @@ actor \nodoc\ _NotificationTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -327,9 +328,10 @@ actor \nodoc\ _NotificationMidQueryTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then

--- a/postgres/_test_parameter_status.pony
+++ b/postgres/_test_parameter_status.pony
@@ -230,9 +230,10 @@ actor \nodoc\ _ParameterStatusTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -319,9 +320,10 @@ actor \nodoc\ _ParameterStatusMidQueryTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then

--- a/postgres/_test_pipeline.pony
+++ b/postgres/_test_pipeline.pony
@@ -132,9 +132,10 @@ actor \nodoc\ _PipelineSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -310,9 +311,10 @@ actor \nodoc\ _PipelineWithFailureTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -485,7 +487,7 @@ actor \nodoc\ _PipelineEmptyTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -494,6 +496,7 @@ actor \nodoc\ _PipelineEmptyTestServer
       _tcp_connection.send(auth_ok)
       _tcp_connection.send(ready)
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestPipelineSingleQuery is UnitTest
   """
@@ -850,9 +853,10 @@ actor \nodoc\ _PipelineShutdownInFlightTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1027,9 +1031,10 @@ actor \nodoc\ _PipelineRowModifyingTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1293,9 +1298,10 @@ actor \nodoc\ _PipelineAllFailTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then

--- a/postgres/_test_protocol_violation.pony
+++ b/postgres/_test_protocol_violation.pony
@@ -117,7 +117,7 @@ actor \nodoc\ _PVParseSCRAMServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if _phase == 0 then
       match _reader.read_startup_message()
@@ -135,6 +135,7 @@ actor \nodoc\ _PVParseSCRAMServer
         _tcp_connection.send(_IncomingJunkTestMessage.bytes())
       end
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationParseInFlight is UnitTest
   """
@@ -248,7 +249,7 @@ actor \nodoc\ _PVParseInFlightServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -263,6 +264,7 @@ actor \nodoc\ _PVParseInFlightServer
         _tcp_connection.send(_IncomingJunkTestMessage.bytes())
       end
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationParseIdle is UnitTest
   """
@@ -357,7 +359,7 @@ actor \nodoc\ _PVParseIdleServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -365,6 +367,7 @@ actor \nodoc\ _PVParseIdleServer
       _tcp_connection.send(_IncomingReadyForQueryTestMessage('I').bytes())
       _tcp_connection.send(_IncomingJunkTestMessage.bytes())
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStatePreAuth is UnitTest
   """
@@ -436,9 +439,9 @@ actor \nodoc\ _PVWrongStatePreAuthServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
-    if _sent then return end
+    if _sent then return lori.KeepReading end
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
       _sent = true
@@ -446,6 +449,7 @@ actor \nodoc\ _PVWrongStatePreAuthServer
         [as (String | None): "1"] end
       _tcp_connection.send(_IncomingDataRowTestMessage(cols).bytes())
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStateSCRAM is UnitTest
   """
@@ -518,7 +522,7 @@ actor \nodoc\ _PVWrongStateSCRAMServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if _phase == 0 then
       match _reader.read_startup_message()
@@ -537,6 +541,7 @@ actor \nodoc\ _PVWrongStateSCRAMServer
           _IncomingAuthenticationCleartextPasswordTestMessage.bytes())
       end
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStateIdle is UnitTest
   """
@@ -607,7 +612,7 @@ actor \nodoc\ _PVWrongStateIdleServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -615,6 +620,7 @@ actor \nodoc\ _PVWrongStateIdleServer
       _tcp_connection.send(_IncomingReadyForQueryTestMessage('I').bytes())
       _tcp_connection.send(_IncomingAuthenticationOkTestMessage.bytes())
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStateInFlight is UnitTest
   """
@@ -688,7 +694,7 @@ actor \nodoc\ _PVWrongStateInFlightServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -703,6 +709,7 @@ actor \nodoc\ _PVWrongStateInFlightServer
         _tcp_connection.send(_IncomingAuthenticationOkTestMessage.bytes())
       end
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationCopyInInFlight is UnitTest
   """

--- a/postgres/_test_session.pony
+++ b/postgres/_test_session.pony
@@ -111,9 +111,10 @@ actor \nodoc\ _JunkSendingTestServer
     let junk = _IncomingJunkTestMessage.bytes()
     _tcp_connection.send(junk)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     let junk = _IncomingJunkTestMessage.bytes()
     _tcp_connection.send(junk)
+    lori.KeepReading
 
 class \nodoc\ iso _TestUnansweredQueriesFailOnShutdown is UnitTest
   """
@@ -248,7 +249,7 @@ actor \nodoc\ _DoesntAnswerTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     """
     Sends AuthenticationOk on first contact without requiring a password.
     Intentionally does NOT send ReadyForQuery afterward — this is the
@@ -259,6 +260,7 @@ actor \nodoc\ _DoesntAnswerTestServer
       let auth_ok = _IncomingAuthenticationOkTestMessage.bytes()
       _tcp_connection.send(auth_ok)
     end
+    lori.KeepReading
 
 class \nodoc\ iso _TestZeroRowSelectReturnsResultSet is UnitTest
   """
@@ -395,9 +397,10 @@ actor \nodoc\ _ZeroRowSelectTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -618,9 +621,10 @@ actor \nodoc\ _TerminateSentTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -806,9 +810,10 @@ actor \nodoc\ _ByteaTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then

--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -116,9 +116,10 @@ actor \nodoc\ _SSLRefusedTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     let response: Array[U8] val = ['N']
     _tcp_connection.send(response)
+    lori.KeepReading
 
 class \nodoc\ iso _TestSSLNegotiationJunkResponse is UnitTest
   """
@@ -234,9 +235,10 @@ actor \nodoc\ _SSLJunkTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     let response: Array[U8] val = ['X']
     _tcp_connection.send(response)
+    lori.KeepReading
 
 class \nodoc\ iso _TestSSLNegotiationSuccess is UnitTest
   """
@@ -371,9 +373,10 @@ actor \nodoc\ _SSLSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _ssl_started then
@@ -626,9 +629,10 @@ actor \nodoc\ _SSLPreferredFallbackTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _ssl_refused then
@@ -785,7 +789,7 @@ class \nodoc\ iso _TestSSLPreferredTLSFailure is UnitTest
       SSLContext
         .> set_client_verify(false)
         .> set_server_verify(false)
-        .> set_min_proto_version(Tls1u3Version())?
+        .> set_min_proto_version(TLS1u3Version())?
     end
 
     let cert_path = FilePath(FileAuth(h.env.root),
@@ -798,7 +802,7 @@ class \nodoc\ iso _TestSSLPreferredTLSFailure is UnitTest
         .> set_cert(cert_path, key_path)?
         .> set_client_verify(false)
         .> set_server_verify(false)
-        .> set_max_proto_version(Tls1u2Version())?
+        .> set_max_proto_version(TLS1u2Version())?
     end
 
     let listener = _SSLPreferredTLSFailureTestListener(
@@ -994,9 +998,10 @@ actor \nodoc\ _SSLPreferredCancelTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _is_cancel_connection then

--- a/postgres/_test_statement_timeout.pony
+++ b/postgres/_test_statement_timeout.pony
@@ -121,9 +121,10 @@ actor \nodoc\ _TimeoutTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _is_cancel_connection then
@@ -409,9 +410,10 @@ actor \nodoc\ _TimeoutCancelledTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then

--- a/postgres/_test_streaming.pony
+++ b/postgres/_test_streaming.pony
@@ -135,9 +135,10 @@ actor \nodoc\ _StreamingSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -349,9 +350,10 @@ actor \nodoc\ _StreamingEmptyTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -524,9 +526,10 @@ actor \nodoc\ _StreamingEarlyStopTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -718,9 +721,10 @@ actor \nodoc\ _StreamingServerErrorTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if _state == 0 then

--- a/postgres/_test_transaction_status.pony
+++ b/postgres/_test_transaction_status.pony
@@ -283,9 +283,10 @@ actor \nodoc\ _TxnStatusTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
+    lori.KeepReading
 
   fun ref _process() =>
     if not _authed then

--- a/postgres/connection_failure_reason.pony
+++ b/postgres/connection_failure_reason.pony
@@ -62,8 +62,15 @@ primitive AuthenticationMethodRejected
 
 primitive ServerVerificationFailed
   """
-  The server's SCRAM signature did not match the expected value. This may
-  indicate a man-in-the-middle attack or a misconfigured server.
+  SCRAM authentication did not verify the server.
+
+  Either the server's signature did not match the expected value, or the
+  verification could not be carried out at all — the server sent a salt or
+  an iteration count that could not be used, or the SCRAM computation
+  failed.
+
+  A signature mismatch may indicate a man-in-the-middle attack or a
+  misconfigured server.
   """
 
 class val InvalidPassword

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -254,8 +254,9 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     end
     state.on_connection_failed(this, r)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     state.on_received(this, consume data)
+    lori.KeepReading
 
   // Routed through the state machine. Each state handles peer close
   // through its own `on_closed` — pre-ready states deliver


### PR DESCRIPTION
lori 0.17.0 has `_on_received` return a `ReadAction` saying whether the read loop should keep reading, and requires ponylang/ssl 3.0.0 and ponyc 0.67.0.

ponylang/ssl 3.0.0 makes `HmacSha256` partial, and SCRAM authentication calls it four times. `compute_proof` was already partial and its caller already treats a failure as `ServerVerificationFailed`, which is the right outcome: two of those four calls build the server signature the client later compares against, so a failure there means the server was never verified.

That reason already covered more than its docstring said — a malformed salt, an unusable iteration count, and a signature mismatch all report it, and only the last is what the docstring described. The docstring now describes what the reason covers, and keeps the man-in-the-middle note attached to the mismatch, where it belongs.
