### PR TITLE
Send TLS close_notify on graceful close

### DIFF
--- a/.release-notes/close-notify.md
+++ b/.release-notes/close-notify.md
@@ -1,0 +1,3 @@
+## Send TLS close_notify on graceful close
+
+Closing a TLS connection now sends a `close_notify` alert before the TCP shutdown. Without it, the peer could not distinguish a clean close from a truncated stream (RFC 8446 §6.1).

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.18.0"
+      "version": "0.18.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Closing a TLS connection now sends a `close_notify` alert before the TCP shutdown. Without it, the peer could not distinguish a clean close from a truncated stream (RFC 8446 §6.1).