### PR TITLE
Add pony-lint CI workflow

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint


### PR DESCRIPTION
Postgres has been linting only via the `pony-lint` job in `breakage-against-ponyc-latest.yml`, which runs when the shared docker builders update. Add a PR-triggered pony-lint workflow so lint findings surface on pull requests, matching the pattern used across other ponylang repos.