### PR TITLE
Require ponyc 0.69.1 or later

### DIFF
--- a/.release-notes/require-ponyc-0.69.1.md
+++ b/.release-notes/require-ponyc-0.69.1.md
@@ -1,0 +1,3 @@
+## Require ponyc 0.69.1 or later
+
+postgres now requires ponyc 0.69.1 or later, up from 0.67.0. Building postgres with an earlier ponyc fails to compile.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ postgres is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.67.0 or later.
+* Requires ponyc 0.69.1 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/postgres.git --version 0.8.2`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.18.1"
+      "version": "0.19.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/postgres/_cancel_sender.pony
+++ b/postgres/_cancel_sender.pony
@@ -47,6 +47,11 @@ actor _CancelSender is
       _tcp_connection.send(_FrontendMessage.ssl_request())
     end
 
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+    // Fire-and-forget: the cancel connection never established, silently give
+    // up. There is nothing to clean up; the connection never connected.
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     // Only called during SSL negotiation — server responds 'S' or 'N'.
     try

--- a/postgres/_test_auth.pony
+++ b/postgres/_test_auth.pony
@@ -325,6 +325,9 @@ actor \nodoc\ _UnsupportedAuthenticationTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if not _received then
       _received = true
@@ -460,6 +463,9 @@ actor \nodoc\ _CleartextTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -669,6 +675,9 @@ actor \nodoc\ _SCRAMTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -793,6 +802,9 @@ actor \nodoc\ _SCRAMUnsupportedTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if not _authed then
       _authed = true
@@ -862,6 +874,9 @@ actor \nodoc\ _SCRAMErrorTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -959,6 +974,9 @@ actor \nodoc\ _SCRAMSkipSASLFinalTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -1079,6 +1097,9 @@ actor \nodoc\ _SCRAMDuplicateSASLContinueTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -1184,6 +1205,9 @@ actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -1282,6 +1306,9 @@ actor \nodoc\ _SCRAMMalformedSASLFinalTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -1391,6 +1418,9 @@ actor \nodoc\ _SCRAMNonceMismatchTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -1494,6 +1524,9 @@ actor \nodoc\ _SCRAMMalformedSASLContinueTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -1843,6 +1876,9 @@ actor \nodoc\ _TooManyConnectionsTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_auth_requirement.pony
+++ b/postgres/_test_auth_requirement.pony
@@ -198,6 +198,9 @@ actor \nodoc\ _AuthMethodRejectedTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()

--- a/postgres/_test_cancel.pony
+++ b/postgres/_test_cancel.pony
@@ -126,6 +126,9 @@ actor \nodoc\ _CancelTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -341,6 +344,9 @@ actor \nodoc\ _SSLCancelTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_connection_closed.pony
+++ b/postgres/_test_connection_closed.pony
@@ -128,6 +128,9 @@ actor \nodoc\ _RemoteCloseAfterSSLRequestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if _closed then return lori.KeepReading end
     _reader.append(consume data)
@@ -240,6 +243,9 @@ actor \nodoc\ _RemoteCloseAfterStartupServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if _closed then return lori.KeepReading end
@@ -355,6 +361,9 @@ actor \nodoc\ _RemoteCloseSCRAMServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -476,6 +485,9 @@ actor \nodoc\ _RemoteCloseLoggedInIdleServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if _closed then return lori.KeepReading end
@@ -624,6 +636,9 @@ actor \nodoc\ _RemoteCloseAfterQueryServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -1411,6 +1426,9 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if _closed then return lori.KeepReading end
     _reader.append(consume data)
@@ -1658,6 +1676,9 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     if _closed then return lori.KeepReading end

--- a/postgres/_test_copy_in.pony
+++ b/postgres/_test_copy_in.pony
@@ -136,6 +136,9 @@ actor \nodoc\ _CopyInSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -312,6 +315,9 @@ actor \nodoc\ _CopyInAbortTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -517,6 +523,9 @@ actor \nodoc\ _CopyInServerErrorTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(
     data: Array[U8] iso)

--- a/postgres/_test_copy_out.pony
+++ b/postgres/_test_copy_out.pony
@@ -127,6 +127,9 @@ actor \nodoc\ _CopyOutSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -292,6 +295,9 @@ actor \nodoc\ _CopyOutEmptyTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -463,6 +469,9 @@ actor \nodoc\ _CopyOutServerErrorTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_notice.pony
+++ b/postgres/_test_notice.pony
@@ -246,6 +246,9 @@ actor \nodoc\ _NoticeTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -339,6 +342,9 @@ actor \nodoc\ _NoticeMidQueryTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_notification.pony
+++ b/postgres/_test_notification.pony
@@ -264,6 +264,9 @@ actor \nodoc\ _NotificationTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -367,6 +370,9 @@ actor \nodoc\ _NotificationMidQueryTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_parameter_status.pony
+++ b/postgres/_test_parameter_status.pony
@@ -255,6 +255,9 @@ actor \nodoc\ _ParameterStatusTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -358,6 +361,9 @@ actor \nodoc\ _ParameterStatusMidQueryTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_pipeline.pony
+++ b/postgres/_test_pipeline.pony
@@ -150,6 +150,9 @@ actor \nodoc\ _PipelineSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -350,6 +353,9 @@ actor \nodoc\ _PipelineWithFailureTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -548,6 +554,9 @@ actor \nodoc\ _PipelineEmptyTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -969,6 +978,9 @@ actor \nodoc\ _PipelineShutdownInFlightTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -1168,6 +1180,9 @@ actor \nodoc\ _PipelineRowModifyingTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -1472,6 +1487,9 @@ actor \nodoc\ _PipelineAllFailTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_protocol_violation.pony
+++ b/postgres/_test_protocol_violation.pony
@@ -127,6 +127,9 @@ actor \nodoc\ _PVParseSCRAMServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if _phase == 0 then
@@ -271,6 +274,9 @@ actor \nodoc\ _PVParseInFlightServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     if not _authed then
@@ -391,6 +397,9 @@ actor \nodoc\ _PVParseIdleServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
@@ -479,6 +488,9 @@ actor \nodoc\ _PVWrongStatePreAuthServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -571,6 +583,9 @@ actor \nodoc\ _PVWrongStateSCRAMServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -671,6 +686,9 @@ actor \nodoc\ _PVWrongStateIdleServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
@@ -761,6 +779,9 @@ actor \nodoc\ _PVWrongStateInFlightServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_session.pony
+++ b/postgres/_test_session.pony
@@ -113,6 +113,9 @@ actor \nodoc\ _JunkSendingTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     let junk = _IncomingJunkTestMessage.bytes()
     _tcp_connection.send(junk)
@@ -262,6 +265,9 @@ actor \nodoc\ _DoesntAnswerTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     """
@@ -418,6 +424,9 @@ actor \nodoc\ _ZeroRowSelectTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -659,6 +668,9 @@ actor \nodoc\ _TerminateSentTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -856,6 +868,9 @@ actor \nodoc\ _ByteaTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -124,6 +124,9 @@ actor \nodoc\ _SSLRefusedTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     let response: Array[U8] val = ['N']
     _tcp_connection.send(response)
@@ -250,6 +253,9 @@ actor \nodoc\ _SSLJunkTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     let response: Array[U8] val = ['X']
@@ -397,6 +403,9 @@ actor \nodoc\ _SSLSuccessTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -687,6 +696,9 @@ actor \nodoc\ _SSLPreferredFallbackTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -1091,6 +1103,9 @@ actor \nodoc\ _SSLPreferredCancelTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_statement_timeout.pony
+++ b/postgres/_test_statement_timeout.pony
@@ -135,6 +135,9 @@ actor \nodoc\ _TimeoutTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -444,6 +447,9 @@ actor \nodoc\ _TimeoutCancelledTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_streaming.pony
+++ b/postgres/_test_streaming.pony
@@ -144,6 +144,9 @@ actor \nodoc\ _StreamingSuccessTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -371,6 +374,9 @@ actor \nodoc\ _StreamingEmptyTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()
@@ -556,6 +562,9 @@ actor \nodoc\ _StreamingEarlyStopTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
@@ -767,6 +776,9 @@ actor \nodoc\ _StreamingServerErrorTestServer
 
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)

--- a/postgres/_test_transaction_status.pony
+++ b/postgres/_test_transaction_status.pony
@@ -292,6 +292,9 @@ actor \nodoc\ _TxnStatusTestServer
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _reader.append(consume data)
     _process()


### PR DESCRIPTION
Updates the lori dependency to 0.19.0 and bumps postgres's minimum ponyc to 0.69.1 to match.

lori 0.19.0 removed the default bodies for the `_on_connection_failure` (client) and `_on_start_failure` (server) lifecycle callbacks, so implementors must provide them. `_CancelSender` and the test server doubles now provide no-op bodies matching lori's previous default, so behavior is unchanged.
