### PR TITLE
Update to work with ponyc 0.70.1

### DIFF
--- a/.release-notes/update-to-work-with-ponyc-0.70.1.md
+++ b/.release-notes/update-to-work-with-ponyc-0.70.1.md
@@ -1,0 +1,3 @@
+## Update to work with ponyc 0.70.1
+
+Updated for compatibility with ponyc 0.70.1.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ postgres is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.69.1 or later.
+* Requires ponyc 0.70.1 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/postgres.git --version 0.9.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -5,11 +5,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.19.0"
+      "version": "0.20.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "4.0.0"
+      "version": "5.0.0"
     }
   ],
   "info": {


### PR DESCRIPTION
Bump ssl dependency to 5.0.0 for ponyc 0.70.0 compatibility.
