### PR TITLE
SSLContext now comes from lori instead of ponylang/ssl

### DIFF
--- a/.release-notes/ssl-context-from-lori.md
+++ b/.release-notes/ssl-context-from-lori.md
@@ -1,0 +1,21 @@
+## SSLContext now comes from lori instead of ponylang/ssl
+
+Lori 0.22.0 replaced its ponylang/ssl dependency with its own SSL types. If you create an `SSLContext` to pass to `SSLRequired` or `SSLPreferred`, import it from lori instead of `ssl/net`:
+
+Before:
+
+```pony
+use "ssl/net"
+
+// ...
+SSLContext
+```
+
+After:
+
+```pony
+use lori = "lori"
+
+// ...
+lori.SSLContext
+```

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.20.0"
+      "version": "0.22.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/examples/ssl-preferred-query/ssl_preferred_query.pony
+++ b/examples/ssl-preferred-query/ssl_preferred_query.pony
@@ -12,7 +12,6 @@ use "cli"
 use "collections"
 use "files"
 use lori = "lori"
-use "ssl/net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -23,7 +22,7 @@ actor Main
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -41,7 +40,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   new create(
     auth: lori.TCPConnectAuth,
     info: ServerInfo,
-    sslctx: SSLContext val,
+    sslctx: lori.SSLContext val,
     out: OutStream)
   =>
     _out = out

--- a/examples/ssl-query/ssl_query.pony
+++ b/examples/ssl-query/ssl_query.pony
@@ -10,7 +10,6 @@ use "cli"
 use "collections"
 use "files"
 use lori = "lori"
-use "ssl/net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -21,7 +20,7 @@ actor Main
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -39,7 +38,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   new create(
     auth: lori.TCPConnectAuth,
     info: ServerInfo,
-    sslctx: SSLContext val,
+    sslctx: lori.SSLContext val,
     out: OutStream)
   =>
     _out = out

--- a/postgres/_cancel_sender.pony
+++ b/postgres/_cancel_sender.pony
@@ -1,5 +1,5 @@
 use lori = "lori"
-use "ssl/net"
+
 
 actor _CancelSender is
   (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)

--- a/postgres/_session_state.pony
+++ b/postgres/_session_state.pony
@@ -2,7 +2,7 @@ use "buffered"
 use "encode/base64"
 use lori = "lori"
 use "ssl/crypto"
-use "ssl/net"
+
 
 interface _SessionState
   fun on_connected(s: Session ref)
@@ -330,7 +330,7 @@ trait _ConnectableState is _UnconnectedState
 
   fun _start_ssl_negotiation(
     s: Session ref,
-    ctx: SSLContext val,
+    ctx: lori.SSLContext val,
     fallback_on_refusal: Bool)
   =>
     // Set buffer_until(1) BEFORE sending SSLRequest so lori delivers exactly

--- a/postgres/_test_cancel.pony
+++ b/postgres/_test_cancel.pony
@@ -1,7 +1,6 @@
 use "files"
 use lori = "lori"
 use "pony_test"
-use "ssl/net"
 
 class \nodoc\ iso _TestCancelQueryInFlight is UnitTest
   """
@@ -231,14 +230,14 @@ class \nodoc\ iso _TestSSLCancelQueryInFlight is UnitTest
 
     let client_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -262,8 +261,8 @@ actor \nodoc\ _SSLCancelTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: SSLContext val
-  let _server_sslctx: SSLContext val
+  let _client_sslctx: lori.SSLContext val
+  let _server_sslctx: lori.SSLContext val
   var _connection_count: USize = 0
 
   new create(
@@ -271,8 +270,8 @@ actor \nodoc\ _SSLCancelTestListener is lori.TCPListenerActor
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: SSLContext val,
-    server_sslctx: SSLContext val)
+    client_sslctx: lori.SSLContext val,
+    server_sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -323,7 +322,7 @@ actor \nodoc\ _SSLCancelTestServer
   (SSL negotiation + verify CancelRequest format and content).
   """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
   let _h: TestHelper
   let _is_cancel_connection: Bool
   var _ssl_started: Bool = false
@@ -332,7 +331,7 @@ actor \nodoc\ _SSLCancelTestServer
 
   new create(
     auth: lori.TCPServerAuth,
-    sslctx: SSLContext val,
+    sslctx: lori.SSLContext val,
     fd: U32,
     h: TestHelper,
     is_cancel: Bool)
@@ -529,7 +528,7 @@ class \nodoc\ iso _TestCancelSSLPgSleep is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end

--- a/postgres/_test_connection_closed.pony
+++ b/postgres/_test_connection_closed.pony
@@ -1,7 +1,6 @@
 use "files"
 use lori = "lori"
 use "pony_test"
-use "ssl/net"
 
 // Tests for peer-initiated TCP close. Each test puts the session in a
 // specific state, then the mock server closes the TCP connection; the
@@ -23,7 +22,7 @@ class \nodoc\ iso _TestRemoteCloseSSLNegotiating is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -73,14 +72,14 @@ actor \nodoc\ _RemoteCloseSSLNegotiatingListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
 
   new create(
     listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: SSLContext val)
+    sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -1721,7 +1720,7 @@ class \nodoc\ iso _TestRemoteCloseSSLNegotiatingPreferred is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -1743,14 +1742,14 @@ actor \nodoc\ _RemoteCloseSSLNegotiatingPreferredListener
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
 
   new create(
     listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: SSLContext val)
+    sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port

--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -1,7 +1,6 @@
 use "files"
 use lori = "lori"
 use "pony_test"
-use "ssl/net"
 
 // SSL negotiation unit tests
 
@@ -19,7 +18,7 @@ class \nodoc\ iso _TestSSLNegotiationRefused is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -71,13 +70,13 @@ actor \nodoc\ _SSLRefusedTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
 
   new create(listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: SSLContext val)
+    sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -148,7 +147,7 @@ class \nodoc\ iso _TestSSLNegotiationJunkResponse is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -201,13 +200,13 @@ actor \nodoc\ _SSLJunkTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
 
   new create(listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: SSLContext val)
+    sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -282,14 +281,14 @@ class \nodoc\ iso _TestSSLNegotiationSuccess is UnitTest
 
     let client_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -341,15 +340,15 @@ actor \nodoc\ _SSLSuccessTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: SSLContext val
-  let _server_sslctx: SSLContext val
+  let _client_sslctx: lori.SSLContext val
+  let _server_sslctx: lori.SSLContext val
 
   new create(listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: SSLContext val,
-    server_sslctx: SSLContext val)
+    client_sslctx: lori.SSLContext val,
+    server_sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -393,11 +392,11 @@ actor \nodoc\ _SSLSuccessTestServer
   connection once it receives the StartupMessage.
   """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
   var _ssl_started: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, sslctx: SSLContext val, fd: U32) =>
+  new create(auth: lori.TCPServerAuth, sslctx: lori.SSLContext val, fd: U32) =>
     _sslctx = sslctx
     _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
 
@@ -450,7 +449,7 @@ class \nodoc\ iso _TestSSLConnect is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -482,7 +481,7 @@ class \nodoc\ iso _TestSSLAuthenticate is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -514,7 +513,7 @@ class \nodoc\ iso _TestSSLQueryResults is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -550,7 +549,7 @@ class \nodoc\ iso _TestSSLRefused is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -585,7 +584,7 @@ class \nodoc\ iso _TestSSLPreferredFallback is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -640,13 +639,13 @@ actor \nodoc\ _SSLPreferredFallbackTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
 
   new create(listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: SSLContext val)
+    sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -746,14 +745,14 @@ class \nodoc\ iso _TestSSLPreferredSuccess is UnitTest
 
     let client_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -804,15 +803,15 @@ actor \nodoc\ _SSLPreferredSuccessTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: SSLContext val
-  let _server_sslctx: SSLContext val
+  let _client_sslctx: lori.SSLContext val
+  let _server_sslctx: lori.SSLContext val
 
   new create(listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: SSLContext val,
-    server_sslctx: SSLContext val)
+    client_sslctx: lori.SSLContext val,
+    server_sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -867,10 +866,10 @@ class \nodoc\ iso _TestSSLPreferredTLSFailure is UnitTest
     // handshake to fail.
     let client_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
-          .> set_min_proto_version(TLS1u3Version())?
+          .> set_min_proto_version(lori.TLS1u3Version())?
       end
 
     let cert_path =
@@ -880,11 +879,11 @@ class \nodoc\ iso _TestSSLPreferredTLSFailure is UnitTest
 
     let server_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
-          .> set_max_proto_version(TLS1u2Version())?
+          .> set_max_proto_version(lori.TLS1u2Version())?
       end
 
     let listener =
@@ -924,15 +923,15 @@ actor \nodoc\ _SSLPreferredTLSFailureTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: SSLContext val
-  let _server_sslctx: SSLContext val
+  let _client_sslctx: lori.SSLContext val
+  let _server_sslctx: lori.SSLContext val
 
   new create(listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: SSLContext val,
-    server_sslctx: SSLContext val)
+    client_sslctx: lori.SSLContext val,
+    server_sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -990,14 +989,14 @@ class \nodoc\ iso _TestSSLPreferredCancelFallback is UnitTest
 
     let client_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -1021,16 +1020,16 @@ actor \nodoc\ _SSLPreferredCancelTestListener is lori.TCPListenerActor
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: SSLContext val
-  let _server_sslctx: SSLContext val
+  let _client_sslctx: lori.SSLContext val
+  let _server_sslctx: lori.SSLContext val
   var _connection_count: USize = 0
 
   new create(listen_auth: lori.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: SSLContext val,
-    server_sslctx: SSLContext val)
+    client_sslctx: lori.SSLContext val,
+    server_sslctx: lori.SSLContext val)
   =>
     _host = host
     _port = port
@@ -1081,7 +1080,7 @@ actor \nodoc\ _SSLPreferredCancelTestServer
   cancel falls back to plaintext, then verifies the CancelRequest.
   """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
-  let _sslctx: SSLContext val
+  let _sslctx: lori.SSLContext val
   let _h: TestHelper
   let _is_cancel_connection: Bool
   var _ssl_started: Bool = false
@@ -1091,7 +1090,7 @@ actor \nodoc\ _SSLPreferredCancelTestServer
 
   new create(
     auth: lori.TCPServerAuth,
-    sslctx: SSLContext val,
+    sslctx: lori.SSLContext val,
     fd: U32,
     h: TestHelper,
     is_cancel: Bool)
@@ -1219,7 +1218,7 @@ class \nodoc\ iso _TestSSLPreferredWithSSLServer is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -1252,7 +1251,7 @@ class \nodoc\ iso _TestSSLPreferredWithPlainServer is UnitTest
 
     let sslctx =
       recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end

--- a/postgres/postgres.pony
+++ b/postgres/postgres.pony
@@ -70,10 +70,8 @@ Two SSL modes are available:
   as plaintext — `pg_session_connection_failed` fires.
 
 ```pony
-use "ssl/net"
-
 let sslctx = recover val
-  SSLContext
+  lori.SSLContext
     .> set_client_verify(true)
     .> set_authority(FilePath(FileAuth(env.root), "/path/to/ca.pem"))?
 end

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -2,7 +2,7 @@ use "buffered"
 use "encode/base64"
 use lori = "lori"
 use "ssl/crypto"
-use "ssl/net"
+
 
 actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   """
@@ -504,7 +504,7 @@ class ref _SessionSSLNegotiating
   """
   let _notify: SessionStatusNotify
   let _database_connect_info: DatabaseConnectInfo
-  let _ssl_ctx: SSLContext val
+  let _ssl_ctx: lori.SSLContext val
   let _host: String
   let _fallback_on_refusal: Bool
   let _codec_registry: CodecRegistry
@@ -513,7 +513,7 @@ class ref _SessionSSLNegotiating
   new ref create(
     notify': SessionStatusNotify,
     database_connect_info': DatabaseConnectInfo,
-    ssl_ctx': SSLContext val,
+    ssl_ctx': lori.SSLContext val,
     host': String,
     fallback_on_refusal': Bool,
     codec_registry': CodecRegistry = CodecRegistry)

--- a/postgres/ssl_mode.pony
+++ b/postgres/ssl_mode.pony
@@ -1,4 +1,4 @@
-use "ssl/net"
+use lori = "lori"
 
 primitive SSLDisabled
   """
@@ -18,18 +18,18 @@ class val SSLPreferred
   matching PostgreSQL's `sslmode=prefer` behavior.
 
   The `SSLContext` controls certificate and cipher configuration. Users must
-  `use "ssl/net"` in their own code to create an `SSLContext val`:
+  `use lori = "lori"` in their own code to create an `SSLContext val`:
 
       let sslctx = recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
       SSLPreferred(sslctx)
   """
-  let ctx: SSLContext val
+  let ctx: lori.SSLContext val
 
-  new val create(ctx': SSLContext val) =>
+  new val create(ctx': lori.SSLContext val) =>
     ctx = ctx'
 
 class val SSLRequired
@@ -39,18 +39,18 @@ class val SSLRequired
   authentication begins.
 
   The `SSLContext` controls certificate and cipher configuration. Users must
-  `use "ssl/net"` in their own code to create an `SSLContext val`:
+  `use lori = "lori"` in their own code to create an `SSLContext val`:
 
       let sslctx = recover val
-        SSLContext
+        lori.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
       SSLRequired(sslctx)
   """
-  let ctx: SSLContext val
+  let ctx: lori.SSLContext val
 
-  new val create(ctx': SSLContext val) =>
+  new val create(ctx': lori.SSLContext val) =>
     ctx = ctx'
 
 type SSLMode is (SSLDisabled | SSLPreferred | SSLRequired)


### PR DESCRIPTION
lori 0.22.0 moved SSLContext and TLS version primitives into lori. All SSLContext references now use lori.SSLContext, and TLS1u2Version/TLS1u3Version are qualified as lori.TLS1u2Version/lori.TLS1u3Version. The ponylang/ssl dependency is kept because postgres uses ssl/crypto for SCRAM-SHA-256 and MD5 authentication.
