### PR TITLE
Update to work with ponyc 0.71.0

### DIFF
--- a/.release-notes/update-ponycheck-api.md
+++ b/.release-notes/update-ponycheck-api.md
@@ -1,0 +1,3 @@
+## Update to work with ponyc 0.71.0
+
+Updated for compatibility with ponyc 0.71.0.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ postgres is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.70.1 or later.
+* Requires ponyc 0.71.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/postgres.git --version 0.10.0`
 * `corral fetch` to fetch your dependencies

--- a/postgres/_test_array.pony
+++ b/postgres/_test_array.pony
@@ -1602,86 +1602,85 @@ primitive \nodoc\ _PgArrayGen
   """
   fun apply(): Generator[(PgArray, U32)] =>
     Generator[(PgArray, U32)](object is GenObj[(PgArray, U32)]
-      fun generate(rnd: Randomness): (PgArray, U32) =>
-        match rnd.usize(0, 17)
-        | 0 => _gen(rnd, 16, 1000)      // bool
-        | 1 => _gen(rnd, 21, 1005)      // int2
-        | 2 => _gen(rnd, 23, 1007)      // int4
-        | 3 => _gen(rnd, 20, 1016)      // int8
-        | 4 => _gen(rnd, 700, 1021)     // float4
-        | 5 => _gen(rnd, 701, 1022)     // float8
-        | 6 => _gen(rnd, 25, 1009)      // text
-        | 7 => _gen(rnd, 1043, 1015)    // varchar
-        | 8 => _gen(rnd, 17, 1001)      // bytea
-        | 9 => _gen(rnd, 1082, 1182)    // date
-        | 10 => _gen(rnd, 1083, 1183)   // time
-        | 11 => _gen(rnd, 1114, 1115)   // timestamp
-        | 12 => _gen(rnd, 1184, 1185)   // timestamptz
-        | 13 => _gen(rnd, 1186, 1187)   // interval
-        | 14 => _gen(rnd, 2950, 2951)   // uuid
-        | 15 => _gen(rnd, 1700, 1231)   // numeric
-        | 16 => _gen(rnd, 26, 1028)     // oid
+      fun generate(rnd: Randomness): (PgArray, U32) ? =>
+        match rnd.usize(0, 17)?
+        | 0 => _gen(rnd, 16, 1000)?      // bool
+        | 1 => _gen(rnd, 21, 1005)?      // int2
+        | 2 => _gen(rnd, 23, 1007)?      // int4
+        | 3 => _gen(rnd, 20, 1016)?      // int8
+        | 4 => _gen(rnd, 700, 1021)?     // float4
+        | 5 => _gen(rnd, 701, 1022)?     // float8
+        | 6 => _gen(rnd, 25, 1009)?      // text
+        | 7 => _gen(rnd, 1043, 1015)?    // varchar
+        | 8 => _gen(rnd, 17, 1001)?      // bytea
+        | 9 => _gen(rnd, 1082, 1182)?    // date
+        | 10 => _gen(rnd, 1083, 1183)?   // time
+        | 11 => _gen(rnd, 1114, 1115)?   // timestamp
+        | 12 => _gen(rnd, 1184, 1185)?   // timestamptz
+        | 13 => _gen(rnd, 1186, 1187)?   // interval
+        | 14 => _gen(rnd, 2950, 2951)?   // uuid
+        | 15 => _gen(rnd, 1700, 1231)?   // numeric
+        | 16 => _gen(rnd, 26, 1028)?     // oid
         else
-          _gen(rnd, 3802, 3807)          // jsonb
+          _gen(rnd, 3802, 3807)?          // jsonb
         end
 
       fun _gen(rnd: Randomness, element_oid: U32, array_oid: U32)
-        : (PgArray, U32)
+        : (PgArray, U32) ?
       =>
-        let size = rnd.usize(0, 5)
+        let size = rnd.usize(0, 5)?
         let elems = recover iso Array[(FieldData | None)](size) end
         for _ in Range(0, size) do
-          if rnd.usize(0, 4) == 0 then
+          if rnd.usize(0, 4)? == 0 then
             elems.push(None)
           else
-            elems.push(_value(rnd, element_oid))
+            elems.push(_value(rnd, element_oid)?)
           end
         end
         (PgArray(element_oid, consume elems), array_oid)
 
-      fun _value(rnd: Randomness, oid: U32): FieldData =>
+      fun _value(rnd: Randomness, oid: U32): FieldData ? =>
         match oid
-        | 16 => rnd.bool()
-        | 21 => rnd.i16()
-        | 23 => rnd.i32()
-        | 20 => rnd.i64()
-        | 700 => F32.from[I32](rnd.i32())
-        | 701 => F64.from[I64](rnd.i64())
+        | 16 => rnd.bool()?
+        | 21 => rnd.i16()?
+        | 23 => rnd.i32()?
+        | 20 => rnd.i64()?
+        | 700 => F32.from[I32](rnd.i32()?)
+        | 701 => F64.from[I64](rnd.i64()?)
         | 17 =>
           Bytea(recover val
-            let a = Array[U8](rnd.usize(0, 10))
+            let a = Array[U8](rnd.usize(0, 10)?)
             for _ in Range(0, a.space()) do
-              a.push(rnd.u8())
+              a.push(rnd.u8()?)
             end
             a
           end)
-        | 1082 => PgDate(rnd.i32())
+        | 1082 => PgDate(rnd.i32()?)
         | 1083 =>
           try
             PgTime(MakePgTimeMicroseconds(
-              (rnd.i64().abs() % 86_400_000_000).i64())
+              (rnd.i64()?.abs() % 86_400_000_000).i64())
               as PgTimeMicroseconds)
           else _Unreachable(); I64(0)
           end
-        | 1114 | 1184 => PgTimestamp(rnd.i64())
-        | 1186 => PgInterval(rnd.i64(), rnd.i32(), rnd.i32())
+        | 1114 | 1184 => PgTimestamp(rnd.i64()?)
+        | 1186 => PgInterval(rnd.i64()?, rnd.i32()?, rnd.i32()?)
         | 2950 => _uuid(rnd)
-        | 1700 => _numeric(rnd)
-        | 26 => rnd.u32().string()
+        | 1700 => _numeric(rnd)?
+        | 26 => rnd.u32()?.string()
         | 3802 =>
-          match rnd.usize(0, 2)
+          match rnd.usize(0, 2)?
           | 0 => "{}"
           | 1 => "\"test\""
           else
-            rnd.i32().string()
+            rnd.i32()?.string()
           end
         else
-          // text-like types: generate simple alpha strings
-          let len = rnd.usize(1, 10)
+          let len = rnd.usize(1, 10)?
           recover val
             let s = String(len)
             for _ in Range(0, len) do
-              s.push((rnd.usize(0, 25) + 97).u8())
+              s.push((rnd.usize(0, 25)? + 97).u8())
             end
             s
           end
@@ -1695,7 +1694,7 @@ primitive \nodoc\ _PgArrayGen
             if (i == 8) or (i == 13) or (i == 18) or (i == 23) then
               s.push('-')
             else
-              try s.push(hex(rnd.usize(0, 15))?)
+              try s.push(hex(rnd.usize(0, 15)?)?)
               else s.push('0')
               end
             end
@@ -1703,12 +1702,12 @@ primitive \nodoc\ _PgArrayGen
           s
         end
 
-      fun _numeric(rnd: Randomness): String =>
-        match rnd.usize(0, 4)
+      fun _numeric(rnd: Randomness): String ? =>
+        match rnd.usize(0, 4)?
         | 0 => "0"
-        | 1 => rnd.u16().string()
+        | 1 => rnd.u16()?.string()
         | 2 =>
-          let v = (rnd.usize(1, 65535)).string()
+          let v = (rnd.usize(1, 65535)?).string()
           recover val "-".clone() .> append(consume v) end
         | 3 => "NaN"
         else

--- a/postgres/_test_equality.pony
+++ b/postgres/_test_equality.pony
@@ -279,12 +279,12 @@ primitive \nodoc\ _FieldDataGen
     Generators.frequency[FieldData](
       [
         (1, Generator[FieldData](object is GenObj[FieldData]
-          fun generate(rnd: Randomness): FieldData =>
-            let size = rnd.usize(0, 10)
+          fun generate(rnd: Randomness): FieldData ? =>
+            let size = rnd.usize(0, 10)?
             Bytea(recover val
               let arr = Array[U8](size)
               for _ in Range(0, size) do
-                arr.push(rnd.u8())
+                arr.push(rnd.u8()?)
               end
               arr
             end)
@@ -310,12 +310,12 @@ primitive \nodoc\ _FieldDataGen
         (1, Generators.ascii_printable(0, 20)
           .map[FieldData]({(v) => v }))
         (1, Generator[FieldData](object is GenObj[FieldData]
-          fun generate(rnd: Randomness): FieldData =>
-            let size = rnd.usize(0, 10)
+          fun generate(rnd: Randomness): FieldData ? =>
+            let size = rnd.usize(0, 10)?
             RawBytes(recover val
               let arr = Array[U8](size)
               for _ in Range(0, size) do
-                arr.push(rnd.u8())
+                arr.push(rnd.u8()?)
               end
               arr
             end)
@@ -332,109 +332,109 @@ primitive \nodoc\ _FieldGen
 primitive \nodoc\ _RowGen
   fun apply(): Generator[Row] =>
     Generator[Row](object is GenObj[Row]
-      fun generate(rnd: Randomness): Row =>
-        let size = rnd.usize(0, 5)
+      fun generate(rnd: Randomness): Row ? =>
+        let size = rnd.usize(0, 5)?
         let fields = recover iso Array[Field](size) end
         for i in Range(0, size) do
           fields.push(
-            Field("f" + i.string(), _random_field_value(rnd)))
+            Field("f" + i.string(), _random_field_value(rnd)?))
         end
         Row(consume fields)
 
-      fun _random_field_value(rnd: Randomness): FieldData =>
-        match rnd.usize(0, 13)
-        | 0 => rnd.bool()
-        | 1 => F32.from[I32](rnd.i32())
-        | 2 => F64.from[I64](rnd.i64())
-        | 3 => rnd.i16()
-        | 4 => rnd.i32()
-        | 5 => rnd.i64()
+      fun _random_field_value(rnd: Randomness): FieldData ? =>
+        match rnd.usize(0, 13)?
+        | 0 => rnd.bool()?
+        | 1 => F32.from[I32](rnd.i32()?)
+        | 2 => F64.from[I64](rnd.i64()?)
+        | 3 => rnd.i16()?
+        | 4 => rnd.i32()?
+        | 5 => rnd.i64()?
         | 6 => None
         | 7 =>
           Bytea(recover val
-            let arr = Array[U8](rnd.usize(0, 10))
+            let arr = Array[U8](rnd.usize(0, 10)?)
             for _ in Range(0, arr.space()) do
-              arr.push(rnd.u8())
+              arr.push(rnd.u8()?)
             end
             arr
           end)
-        | 8 => PgDate(rnd.i32())
-        | 9 => PgInterval(rnd.i64(), rnd.i32(), rnd.i32())
+        | 8 => PgDate(rnd.i32()?)
+        | 9 => PgInterval(rnd.i64()?, rnd.i32()?, rnd.i32()?)
         | 10 =>
             try
               PgTime(MakePgTimeMicroseconds(
-                (rnd.i64().abs() % 86_400_000_000).i64())
+                (rnd.i64()?.abs() % 86_400_000_000).i64())
                 as PgTimeMicroseconds)
             else _Unreachable(); I64(0)
             end
-        | 11 => PgTimestamp(rnd.i64())
+        | 11 => PgTimestamp(rnd.i64()?)
         | 12 =>
           RawBytes(recover val
-            let arr = Array[U8](rnd.usize(0, 10))
+            let arr = Array[U8](rnd.usize(0, 10)?)
             for _ in Range(0, arr.space()) do
-              arr.push(rnd.u8())
+              arr.push(rnd.u8()?)
             end
             arr
           end)
         else
-          "str" + rnd.u32().string()
+          "str" + rnd.u32()?.string()
         end
     end)
 
 primitive \nodoc\ _RowsGen
   fun apply(): Generator[Rows] =>
     Generator[Rows](object is GenObj[Rows]
-      fun generate(rnd: Randomness): Rows =>
-        let size = rnd.usize(0, 3)
+      fun generate(rnd: Randomness): Rows ? =>
+        let size = rnd.usize(0, 3)?
         let rows = recover iso Array[Row](size) end
         for i in Range(0, size) do
-          let field_count = rnd.usize(0, 5)
+          let field_count = rnd.usize(0, 5)?
           let fields = recover iso Array[Field](field_count) end
           for j in Range(0, field_count) do
             fields.push(
-              Field("f" + j.string(), _random_field_value(rnd)))
+              Field("f" + j.string(), _random_field_value(rnd)?))
           end
           rows.push(Row(consume fields))
         end
         Rows(consume rows)
 
-      fun _random_field_value(rnd: Randomness): FieldData =>
-        match rnd.usize(0, 13)
-        | 0 => rnd.bool()
-        | 1 => F32.from[I32](rnd.i32())
-        | 2 => F64.from[I64](rnd.i64())
-        | 3 => rnd.i16()
-        | 4 => rnd.i32()
-        | 5 => rnd.i64()
+      fun _random_field_value(rnd: Randomness): FieldData ? =>
+        match rnd.usize(0, 13)?
+        | 0 => rnd.bool()?
+        | 1 => F32.from[I32](rnd.i32()?)
+        | 2 => F64.from[I64](rnd.i64()?)
+        | 3 => rnd.i16()?
+        | 4 => rnd.i32()?
+        | 5 => rnd.i64()?
         | 6 => None
         | 7 =>
           Bytea(recover val
-            let arr = Array[U8](rnd.usize(0, 10))
+            let arr = Array[U8](rnd.usize(0, 10)?)
             for _ in Range(0, arr.space()) do
-              arr.push(rnd.u8())
+              arr.push(rnd.u8()?)
             end
             arr
           end)
-        | 8 => PgDate(rnd.i32())
-        | 9 => PgInterval(rnd.i64(), rnd.i32(), rnd.i32())
+        | 8 => PgDate(rnd.i32()?)
+        | 9 => PgInterval(rnd.i64()?, rnd.i32()?, rnd.i32()?)
         | 10 =>
             try
               PgTime(MakePgTimeMicroseconds(
-                (rnd.i64().abs() % 86_400_000_000).i64())
+                (rnd.i64()?.abs() % 86_400_000_000).i64())
                 as PgTimeMicroseconds)
             else _Unreachable(); I64(0)
             end
-        | 11 => PgTimestamp(rnd.i64())
+        | 11 => PgTimestamp(rnd.i64()?)
         | 12 =>
           RawBytes(recover val
-            let arr = Array[U8](rnd.usize(0, 10))
+            let arr = Array[U8](rnd.usize(0, 10)?)
             for _ in Range(0, arr.space()) do
-              arr.push(rnd.u8())
+              arr.push(rnd.u8()?)
             end
             arr
           end)
         else
-          "str" + rnd.u32().string()
+          "str" + rnd.u32()?.string()
         end
     end)
 

--- a/postgres/_test_response_parser.pony
+++ b/postgres/_test_response_parser.pony
@@ -1702,134 +1702,134 @@ primitive \nodoc\ _RandomMessageBytesGen
     rnd: Randomness,
     min_count: USize = 2,
     max_count: USize = 8)
-    : Array[Array[U8] val] val
+    : Array[Array[U8] val] val ?
   =>
-    let count = rnd.usize(min_count, max_count)
+    let count = rnd.usize(min_count, max_count)?
     let messages = recover iso Array[Array[U8] val](count) end
     for _ in Range(0, count) do
-      messages.push(_random_message(rnd))
+      messages.push(_random_message(rnd)?)
     end
     consume messages
 
-  fun _random_message(rnd: Randomness): Array[U8] val =>
-    match rnd.usize(0, 26)
+  fun _random_message(rnd: Randomness): Array[U8] val ? =>
+    match rnd.usize(0, 26)?
     | 0 => _IncomingAuthenticationOkTestMessage.bytes()
     | 1 =>
       _IncomingAuthenticationCleartextPasswordTestMessage.bytes()
     | 2 =>
       _IncomingAuthenticationMD5PasswordTestMessage(
-        _random_salt(rnd)).bytes()
+        _random_salt(rnd)?).bytes()
     | 3 =>
       let mechanisms: Array[String] val =
         recover val ["SCRAM-SHA-256"] end
       _IncomingAuthenticationSASLTestMessage(mechanisms).bytes()
     | 4 =>
       _IncomingAuthenticationSASLContinueTestMessage(
-        _random_bytes(rnd)).bytes()
+        _random_bytes(rnd)?).bytes()
     | 5 =>
       _IncomingAuthenticationSASLFinalTestMessage(
-        _random_bytes(rnd)).bytes()
+        _random_bytes(rnd)?).bytes()
     | 6 =>
       _IncomingUnsupportedAuthenticationTestMessage(
-        _random_unsupported_auth_type(rnd)).bytes()
+        _random_unsupported_auth_type(rnd)?).bytes()
     | 7 =>
-      _IncomingBackendKeyDataTestMessage(rnd.i32(), rnd.i32()).bytes()
+      _IncomingBackendKeyDataTestMessage(rnd.i32()?, rnd.i32()?).bytes()
     | 8 =>
       _IncomingCommandCompleteTestMessage(
-        _random_command_tag(rnd)).bytes()
+        _random_command_tag(rnd)?).bytes()
     | 9 =>
       _IncomingCopyInResponseTestMessage(
-        _random_copy_format(rnd), _random_column_formats(rnd)).bytes()
+        _random_copy_format(rnd)?, _random_column_formats(rnd)?).bytes()
     | 10 =>
       _IncomingCopyOutResponseTestMessage(
-        _random_copy_format(rnd), _random_column_formats(rnd)).bytes()
+        _random_copy_format(rnd)?, _random_column_formats(rnd)?).bytes()
     | 11 =>
-      _IncomingCopyDataTestMessage(_random_bytes(rnd)).bytes()
+      _IncomingCopyDataTestMessage(_random_bytes(rnd)?).bytes()
     | 12 => _IncomingCopyDoneTestMessage.bytes()
     | 13 =>
       _IncomingDataRowTestMessage(
-        _random_data_row_columns(rnd)).bytes()
+        _random_data_row_columns(rnd)?).bytes()
     | 14 => _IncomingEmptyQueryResponseTestMessage.bytes()
     | 15 =>
       _IncomingErrorResponseTestMessage(
-        _safe_string(rnd), _safe_string(rnd), _safe_string(rnd)).bytes()
+        _safe_string(rnd)?, _safe_string(rnd)?, _safe_string(rnd)?).bytes()
     | 16 =>
       _IncomingNoticeResponseTestMessage(
-        _safe_string(rnd), _safe_string(rnd), _safe_string(rnd)).bytes()
+        _safe_string(rnd)?, _safe_string(rnd)?, _safe_string(rnd)?).bytes()
     | 17 =>
       _IncomingNotificationResponseTestMessage(
-        rnd.i32(), _safe_string(rnd), _safe_string(rnd)).bytes()
+        rnd.i32()?, _safe_string(rnd)?, _safe_string(rnd)?).bytes()
     | 18 =>
       _IncomingParameterStatusTestMessage(
-        _safe_string(rnd), _safe_string(rnd)).bytes()
+        _safe_string(rnd)?, _safe_string(rnd)?).bytes()
     | 19 =>
-      _IncomingReadyForQueryTestMessage(_random_rfq_status(rnd)).bytes()
+      _IncomingReadyForQueryTestMessage(_random_rfq_status(rnd)?).bytes()
     | 20 =>
       _IncomingRowDescriptionTestMessage(
-        _random_row_desc_columns(rnd)).bytes()
+        _random_row_desc_columns(rnd)?).bytes()
     | 21 => _IncomingParseCompleteTestMessage.bytes()
     | 22 => _IncomingBindCompleteTestMessage.bytes()
     | 23 => _IncomingNoDataTestMessage.bytes()
     | 24 => _IncomingCloseCompleteTestMessage.bytes()
     | 25 =>
       _IncomingParameterDescriptionTestMessage(
-        _random_oids(rnd)).bytes()
+        _random_oids(rnd)?).bytes()
     | 26 => _IncomingPortalSuspendedTestMessage.bytes()
     else
       _IncomingAuthenticationOkTestMessage.bytes()
     end
 
-  fun _safe_string(rnd: Randomness): String =>
-    let size = rnd.usize(1, 20)
+  fun _safe_string(rnd: Randomness): String ? =>
+    let size = rnd.usize(1, 20)?
     recover val
       let s = String(size)
       for _ in Range(0, size) do
-        s.push(rnd.u8(32, 126))
+        s.push(rnd.u8(32, 126)?)
       end
       s
     end
 
-  fun _random_salt(rnd: Randomness): String =>
+  fun _random_salt(rnd: Randomness): String ? =>
     recover val
       let s = String(4)
       for _ in Range(0, 4) do
-        s.push(rnd.u8(32, 126))
+        s.push(rnd.u8(32, 126)?)
       end
       s
     end
 
-  fun _random_bytes(rnd: Randomness): Array[U8] val =>
-    let size = rnd.usize(1, 50)
+  fun _random_bytes(rnd: Randomness): Array[U8] val ? =>
+    let size = rnd.usize(1, 50)?
     recover val
       let arr = Array[U8](size)
       for _ in Range(0, size) do
-        arr.push(rnd.u8())
+        arr.push(rnd.u8()?)
       end
       arr
     end
 
-  fun _random_rfq_status(rnd: Randomness): U8 =>
-    match rnd.usize(0, 2)
+  fun _random_rfq_status(rnd: Randomness): U8 ? =>
+    match rnd.usize(0, 2)?
     | 0 => 'I'
     | 1 => 'T'
     else
       'E'
     end
 
-  fun _random_command_tag(rnd: Randomness): String =>
-    match rnd.usize(0, 6)
-    | 0 => "SELECT " + rnd.usize(0, 100).string()
-    | 1 => "INSERT 0 " + rnd.usize(0, 100).string()
-    | 2 => "DELETE " + rnd.usize(0, 100).string()
-    | 3 => "UPDATE " + rnd.usize(0, 100).string()
+  fun _random_command_tag(rnd: Randomness): String ? =>
+    match rnd.usize(0, 6)?
+    | 0 => "SELECT " + rnd.usize(0, 100)?.string()
+    | 1 => "INSERT 0 " + rnd.usize(0, 100)?.string()
+    | 2 => "DELETE " + rnd.usize(0, 100)?.string()
+    | 3 => "UPDATE " + rnd.usize(0, 100)?.string()
     | 4 => "CREATE TABLE"
     | 5 => "DROP TABLE"
     else
-      "COPY " + rnd.usize(0, 100).string()
+      "COPY " + rnd.usize(0, 100)?.string()
     end
 
-  fun _random_unsupported_auth_type(rnd: Randomness): I32 =>
-    match rnd.usize(0, 3)
+  fun _random_unsupported_auth_type(rnd: Randomness): I32 ? =>
+    match rnd.usize(0, 3)?
     | 0 => 2
     | 1 => 4
     | 2 => 6
@@ -1837,43 +1837,45 @@ primitive \nodoc\ _RandomMessageBytesGen
       7
     end
 
-  fun _random_oids(rnd: Randomness): Array[U32] val =>
-    let size = rnd.usize(0, 5)
+  fun _random_oids(rnd: Randomness): Array[U32] val ? =>
+    let size = rnd.usize(0, 5)?
     recover val
       let arr = Array[U32](size)
       for _ in Range(0, size) do
-        arr.push(rnd.u32())
+        arr.push(rnd.u32()?)
       end
       arr
     end
 
-  fun _random_copy_format(rnd: Randomness): U8 =>
-    if rnd.bool() then 1 else 0 end
+  fun _random_copy_format(rnd: Randomness): U8 ? =>
+    if rnd.bool()? then 1 else 0 end
 
-  fun _random_column_formats(rnd: Randomness): Array[U8] val =>
-    let size = rnd.usize(0, 5)
+  fun _random_column_formats(rnd: Randomness): Array[U8] val ? =>
+    let size = rnd.usize(0, 5)?
     recover val
       let arr = Array[U8](size)
       for _ in Range(0, size) do
-        arr.push(if rnd.bool() then 1 else 0 end)
+        arr.push(if rnd.bool()? then 1 else 0 end)
       end
       arr
     end
 
-  fun _random_data_row_columns(rnd: Randomness): Array[(String | None)] val =>
-    let size = rnd.usize(0, 4)
+  fun _random_data_row_columns(rnd: Randomness)
+    : Array[(String | None)] val ?
+  =>
+    let size = rnd.usize(0, 4)?
     let arr = recover iso Array[(String | None)](size) end
     for _ in Range(0, size) do
-      if rnd.bool() then
+      if rnd.bool()? then
         arr.push(None)
       else
-        arr.push(_safe_string(rnd))
+        arr.push(_safe_string(rnd)?)
       end
     end
     consume arr
 
   fun _random_row_desc_columns(rnd: Randomness):
-    Array[(String, U32, U16)] val
+    Array[(String, U32, U16)] val ?
   =>
     let known_oids: Array[U32] val =
       recover val
@@ -1881,12 +1883,12 @@ primitive \nodoc\ _RandomMessageBytesGen
           25; 23; 20; 16; 21; 700; 701; 17
           1082; 1083; 1114; 1184; 1186]
       end
-    let size = rnd.usize(1, 5)
+    let size = rnd.usize(1, 5)?
     let arr = recover iso Array[(String, U32, U16)](size) end
     for i in Range(0, size) do
       try
-        let type_idx = rnd.usize(0, known_oids.size() - 1)
-        let fmt = rnd.usize(0, 1).u16()
+        let type_idx = rnd.usize(0, known_oids.size() - 1)?
+        let fmt = rnd.usize(0, 1)?.u16()
         arr.push(("col" + i.string(), known_oids(type_idx)?, fmt))
       end
     end
@@ -1900,8 +1902,8 @@ class \nodoc\ iso _TestResponseParserMultipleMessagesChainProperty
   fun gen(): Generator[Array[Array[U8] val] val] =>
     Generator[Array[Array[U8] val] val](
       object is GenObj[Array[Array[U8] val] val]
-        fun generate(rnd: Randomness): Array[Array[U8] val] val =>
-          _RandomMessageBytesGen(rnd)
+        fun generate(rnd: Randomness): Array[Array[U8] val] val ? =>
+          _RandomMessageBytesGen(rnd)?
       end)
 
   fun ref property(arg1: Array[Array[U8] val] val, h: PropertyHelper) ? =>


### PR DESCRIPTION
Update property tests and test generators for compatibility with the PonyCheck internal-shrinking API in ponyc 0.71.0.

All `Randomness` draw methods (`.usize()`, `.bool()`, `.i32()`, etc.) are now partial. The `generate` functions and helper methods in `_test_response_parser.pony`, `_test_equality.pony`, and `_test_array.pony` are updated to propagate partiality.
