### PR TITLE
Update to work with ponyc 0.72.0

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     services:
       postgres:
         image: postgres:14.5

--- a/.release-notes/update-to-ponyc-0.72.0.md
+++ b/.release-notes/update-to-ponyc-0.72.0.md
@@ -1,0 +1,3 @@
+## Update to work with ponyc 0.72.0
+
+The lori networking library has been merged into ponyc's stdlib as the `net` package. postgres now uses stdlib `net` directly instead of depending on lori as an external package. You no longer need lori in your `corral.json`. Change `use lori = "lori"` to `use "net"` and drop the `lori.` qualifier from type names.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Integration tests need two PostgreSQL 14.5 containers, started by `make start-pg
 
 ## Architecture
 
-The `Session` actor is the entry point. It implements `lori.TCPConnectionActor` and `lori.ClientLifecycleEventReceiver` and tracks its lifecycle with explicit `_SessionState` classes. Session state is composed from a trait hierarchy that supplies each state's default responses, so a concrete state writes only the transitions that differ from those defaults; the rest fall through to a trait default — a panic (`_IllegalState()`), a protocol-violation handler, or a deliberate no-op, depending on the state.
+The `Session` actor is the entry point. It implements `net.TCPConnectionActor` and `net.ClientLifecycleEventReceiver` and tracks its lifecycle with explicit `_SessionState` classes. Session state is composed from a trait hierarchy that supplies each state's default responses, so a concrete state writes only the transitions that differ from those defaults; the rest fall through to a trait default — a panic (`_IllegalState()`), a protocol-violation handler, or a deliberate no-op, depending on the state.
 
 ```
 _SessionUnopened  --connect (no SSL)-->              _SessionConnected

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ postgres is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.71.0 or later.
+* Requires ponyc 0.72.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/postgres.git --version 0.11.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -4,10 +4,6 @@
   ],
   "deps": [
     {
-      "locator": "github.com/ponylang/lori.git",
-      "version": "0.22.0"
-    },
-    {
       "locator": "github.com/ponylang/ssl.git",
       "version": "5.0.0"
     }

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ Query cancellation using `Session.cancel()`. Executes a long-running query (`SEL
 
 ## connection-timeout
 
-Connection timeout using the `connection_timeout` parameter on `ServerConnectInfo`. Connects to a configurable host and port with a 3-second timeout via `lori.MakeConnectionTimeout(3000)`, and handles `ConnectionFailedTimeout` in `pg_session_connection_failed`. Shows how the driver reports unreachable servers without hanging indefinitely.
+Connection timeout using the `connection_timeout` parameter on `ServerConnectInfo`. Connects to a configurable host and port with a 3-second timeout via `MakeConnectionTimeout(3000)`, and handles `ConnectionFailedTimeout` in `pg_session_connection_failed`. Shows how the driver reports unreachable servers without hanging indefinitely.
 
 ## composite-type
 
@@ -82,7 +82,7 @@ Server notice handling using `pg_notice`. Executes `DROP TABLE IF EXISTS` on a n
 
 ## statement-timeout
 
-Statement timeout using the `statement_timeout` parameter on `session.execute()`. Executes a long-running query (`SELECT pg_sleep(10)`) with a 2-second timeout via `lori.MakeTimerDuration(2000)`, and handles the resulting `ErrorResponseMessage` with SQLSTATE `57014` (query_canceled). Shows how the driver automatically cancels a query that exceeds the timeout, using the same CancelRequest mechanism as `session.cancel()`.
+Statement timeout using the `statement_timeout` parameter on `session.execute()`. Executes a long-running query (`SELECT pg_sleep(10)`) with a 2-second timeout via `MakeTimerDuration(2000)`, and handles the resulting `ErrorResponseMessage` with SQLSTATE `57014` (query_canceled). Shows how the driver automatically cancels a query that exceeds the timeout, using the same CancelRequest mechanism as `session.cancel()`.
 
 ## temporal
 

--- a/examples/array/array.pony
+++ b/examples/array/array.pony
@@ -5,7 +5,7 @@ binary-format encoding and decoding.
 
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -13,7 +13,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -26,7 +26,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _out: OutStream
   var _step: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/bytea/bytea.pony
+++ b/examples/bytea/bytea.pony
@@ -6,7 +6,7 @@ raw byte arrays.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -14,7 +14,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -25,7 +25,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/cancel/cancel.pony
+++ b/examples/cancel/cancel.pony
@@ -5,7 +5,7 @@ calls `session.cancel()`, and checks for SQLSTATE 57014
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -13,7 +13,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -24,7 +24,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/composite-type/composite_type.pony
+++ b/examples/composite-type/composite_type.pony
@@ -11,7 +11,7 @@ sending a `PgComposite` as a query parameter.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -19,7 +19,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
     Client(auth, server_info, env.out)
 
 actor Client is (SessionStatusNotify & ResultReceiver)
@@ -28,14 +28,14 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   then reconnects with a composite-aware registry to query and send
   PgComposite values.
   """
-  let _auth: lori.TCPConnectAuth
+  let _auth: net.TCPConnectAuth
   let _info: ServerInfo
   let _out: OutStream
   var _session: Session
   var _phase: USize = 0
   var _composite_oid: U32 = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _auth = auth
     _info = info
     _out = out

--- a/examples/connection-timeout/connection_timeout.pony
+++ b/examples/connection-timeout/connection_timeout.pony
@@ -7,7 +7,7 @@ timeout. If the server is unreachable within the timeout, the session reports
 use "cli"
 use "collections"
 use "constrained_types"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -15,7 +15,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -26,10 +26,10 @@ actor Client is SessionStatusNotify
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
-    match \exhaustive\ lori.MakeConnectionTimeout(3000)
-    | let ct: lori.ConnectionTimeout =>
+    match \exhaustive\ net.MakeConnectionTimeout(3000)
+    | let ct: net.ConnectionTimeout =>
       _out.print("Connecting with 3-second timeout...")
       _session =
         Session(

--- a/examples/copy-in/copy_in.pony
+++ b/examples/copy-in/copy_in.pony
@@ -7,7 +7,7 @@ the next chunk. Call `finish_copy` when all data is sent.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -15,7 +15,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -29,7 +29,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyInReceiver)
   var _phase: USize = 0
   var _rows_sent: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/copy-out/copy_out.pony
+++ b/examples/copy-out/copy_out.pony
@@ -8,7 +8,7 @@ has been sent.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -16,7 +16,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -30,7 +30,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & CopyOutReceiver)
   var _phase: USize = 0
   var _copy_data: Array[U8] iso = recover iso Array[U8] end
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/crud/crud.pony
+++ b/examples/crud/crud.pony
@@ -5,7 +5,7 @@ them, and drops the table.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -13,7 +13,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -31,7 +31,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _out: OutStream
   var _phase: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/custom-codec/custom_codec.pony
+++ b/examples/custom-codec/custom_codec.pony
@@ -6,7 +6,7 @@ results.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -14,7 +14,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
     Client(auth, server_info, env.out)
 
 class val Point is (FieldData & Equatable[Point])
@@ -80,7 +80,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     // Register the custom codec for point (OID 600) and pass it to Session.
     // The fallback can't execute — OID 600 is not a built-in.

--- a/examples/enum-type/enum_type.pony
+++ b/examples/enum-type/enum_type.pony
@@ -12,7 +12,7 @@ their OIDs aren't known at compile time.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -20,7 +20,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
     Client(auth, server_info, env.out)
 
 // Two-phase example: first session discovers the enum OID, second session
@@ -32,13 +32,13 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   Discovers a PostgreSQL enum OID in one session, then queries with
   an enum-aware codec registry in a second session.
   """
-  let _auth: lori.TCPConnectAuth
+  let _auth: net.TCPConnectAuth
   let _info: ServerInfo
   let _out: OutStream
   var _session: Session
   var _phase: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _auth = auth
     _info = info
     _out = out

--- a/examples/failover/failover.pony
+++ b/examples/failover/failover.pony
@@ -9,7 +9,7 @@ ports), so the session targeting the real server wins the race.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -17,7 +17,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     Failover(auth, server_info, env.out)
 
@@ -31,7 +31,7 @@ actor Failover is (SessionStatusNotify & ResultReceiver)
   var _failures: USize = 0
   var _winner: (Session | None) = None
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     let db = DatabaseConnectInfo(info.username, info.password, info.database)
 

--- a/examples/listen-notify/listen_notify.pony
+++ b/examples/listen-notify/listen_notify.pony
@@ -4,7 +4,7 @@ receives it via the `pg_notification` callback, then unsubscribes.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -12,7 +12,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -24,7 +24,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _out: OutStream
   var _phase: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/named-prepared-query/named_prepared_query.pony
+++ b/examples/named-prepared-query/named_prepared_query.pony
@@ -5,7 +5,7 @@ parameter values via `NamedPreparedQuery`.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -13,7 +13,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -25,7 +25,7 @@ actor Client is (SessionStatusNotify & ResultReceiver & PrepareReceiver)
   let _out: OutStream
   var _executions_remaining: U32 = 2
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/notice/notice.pony
+++ b/examples/notice/notice.pony
@@ -4,7 +4,7 @@ a server notice, then prints the notice fields via `pg_notice`.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -12,7 +12,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -23,7 +23,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/parameter-status/parameter_status.pony
+++ b/examples/parameter-status/parameter_status.pony
@@ -4,7 +4,7 @@ startup, then changes `application_name` with SET and prints the update.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -12,7 +12,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -23,7 +23,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/pipeline/pipeline.pony
+++ b/examples/pipeline/pipeline.pony
@@ -9,7 +9,7 @@ if one fails, the others continue executing.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -17,7 +17,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -30,7 +30,7 @@ actor Client is
   let _out: OutStream
   var _phase: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/prepared-query/prepared_query.pony
+++ b/examples/prepared-query/prepared_query.pony
@@ -3,7 +3,7 @@ Runs a prepared query with typed parameters against a PostgreSQL server.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -11,7 +11,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -22,7 +22,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/query/query.pony
+++ b/examples/query/query.pony
@@ -3,7 +3,7 @@ Runs a simple query against a PostgreSQL server and prints the result.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -11,7 +11,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -22,7 +22,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/ssl-preferred-query/ssl_preferred_query.pony
+++ b/examples/ssl-preferred-query/ssl_preferred_query.pony
@@ -11,7 +11,7 @@ mandatory and you'd rather fail than connect without it.
 use "cli"
 use "collections"
 use "files"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -22,12 +22,12 @@ actor Main
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
     Client(auth, server_info, sslctx, env.out)
 
 actor Client is (SessionStatusNotify & ResultReceiver)
@@ -38,9 +38,9 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _out: OutStream
 
   new create(
-    auth: lori.TCPConnectAuth,
+    auth: net.TCPConnectAuth,
     info: ServerInfo,
-    sslctx: lori.SSLContext val,
+    sslctx: net.SSLContext val,
     out: OutStream)
   =>
     _out = out

--- a/examples/ssl-query/ssl_query.pony
+++ b/examples/ssl-query/ssl_query.pony
@@ -9,7 +9,7 @@ environment variables to match your server configuration.
 use "cli"
 use "collections"
 use "files"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -20,12 +20,12 @@ actor Main
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
     Client(auth, server_info, sslctx, env.out)
 
 actor Client is (SessionStatusNotify & ResultReceiver)
@@ -36,9 +36,9 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _out: OutStream
 
   new create(
-    auth: lori.TCPConnectAuth,
+    auth: net.TCPConnectAuth,
     info: ServerInfo,
-    sslctx: lori.SSLContext val,
+    sslctx: net.SSLContext val,
     out: OutStream)
   =>
     _out = out

--- a/examples/statement-timeout/statement_timeout.pony
+++ b/examples/statement-timeout/statement_timeout.pony
@@ -7,7 +7,7 @@ CancelRequest and the query fails with SQLSTATE 57014 (query_canceled).
 use "cli"
 use "collections"
 use "constrained_types"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -15,7 +15,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -26,7 +26,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(
@@ -40,8 +40,8 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   be pg_session_authenticated(session: Session) =>
     _out.print("Authenticated.")
 
-    match \exhaustive\ lori.MakeTimerDuration(2000)
-    | let d: lori.TimerDuration =>
+    match \exhaustive\ net.MakeTimerDuration(2000)
+    | let d: net.TimerDuration =>
       _out.print("Sending long-running query with 2-second timeout....")
       let q = SimpleQuery("SELECT pg_sleep(10)")
       session.execute(q, this where statement_timeout = d)

--- a/examples/streaming/streaming.pony
+++ b/examples/streaming/streaming.pony
@@ -5,7 +5,7 @@ with 7 rows, streams them with a window size of 3 (producing batches of
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -13,7 +13,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -29,7 +29,7 @@ actor Client is
   let _out: OutStream
   var _phase: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/temporal/temporal.pony
+++ b/examples/temporal/temporal.pony
@@ -4,7 +4,7 @@ a prepared query and prints the typed results.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -12,7 +12,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -23,7 +23,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _session: Session
   let _out: OutStream
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/examples/transaction-status/transaction_status.pony
+++ b/examples/transaction-status/transaction_status.pony
@@ -4,7 +4,7 @@ COMMIT; the status changes from idle to in-transaction and back.
 """
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 // in your code this `use` statement would be:
 // use "postgres"
 use "../../postgres"
@@ -12,7 +12,7 @@ use "../../postgres"
 actor Main
   new create(env: Env) =>
     let server_info = ServerInfo(env.vars)
-    let auth = lori.TCPConnectAuth(env.root)
+    let auth = net.TCPConnectAuth(env.root)
 
     let client = Client(auth, server_info, env.out)
 
@@ -24,7 +24,7 @@ actor Client is (SessionStatusNotify & ResultReceiver)
   let _out: OutStream
   var _phase: USize = 0
 
-  new create(auth: lori.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
+  new create(auth: net.TCPConnectAuth, info: ServerInfo, out: OutStream) =>
     _out = out
     _session =
       Session(

--- a/postgres/_cancel_sender.pony
+++ b/postgres/_cancel_sender.pony
@@ -1,8 +1,8 @@
-use lori = "lori"
+use net = "net"
 
 
 actor _CancelSender is
-  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+  (net.TCPConnectionActor & net.ClientLifecycleEventReceiver)
   """
   Fire-and-forget actor that sends a CancelRequest on a separate TCP
   connection. PostgreSQL requires cancel requests on a different connection
@@ -17,7 +17,7 @@ actor _CancelSender is
   the server refuses SSL ('N'), the cancel proceeds over plaintext; TLS
   handshake failure still silently abandons.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _process_id: I32
   let _secret_key: I32
   let _info: ServerConnectInfo
@@ -27,10 +27,10 @@ actor _CancelSender is
     _secret_key = secret_key
     _info = info
     _tcp_connection =
-      lori.TCPConnection.client(
+      net.TCPConnection.client(
         info.auth, info.host, info.service, "", this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
   fun ref _on_connected() =>
@@ -39,20 +39,20 @@ actor _CancelSender is
       _send_cancel_and_close()
     | let _: (SSLRequired | SSLPreferred) =>
       // CVE-2021-23222 mitigation: buffer exactly 1 byte for SSL response.
-      match \exhaustive\ lori.MakeBufferSize(1)
-      | let e: lori.BufferSize => _tcp_connection.buffer_until(e)
+      match \exhaustive\ net.MakeBufferSize(1)
+      | let e: net.BufferSize => _tcp_connection.buffer_until(e)
       else
         _Unreachable()
       end
       _tcp_connection.send(_FrontendMessage.ssl_request())
     end
 
-  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+  fun ref _on_connection_failure(reason: net.ConnectionFailureReason) =>
     // Fire-and-forget: the cancel connection never established, silently give
     // up. There is nothing to clean up; the connection never connected.
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     // Only called during SSL negotiation — server responds 'S' or 'N'.
     try
       if data(0)? == 'S' then
@@ -62,18 +62,18 @@ actor _CancelSender is
           | let pref: SSLPreferred => pref.ctx
           else
             _tcp_connection.close()
-            return lori.KeepReading
+            return net.KeepReading
           end
         match \exhaustive\ _tcp_connection.start_tls(ctx, _info.host)
         | None => None  // Handshake started, wait for _on_tls_ready
-        | let _: lori.StartTLSError =>
+        | let _: net.StartTLSError =>
           _tcp_connection.close()
         end
       elseif data(0)? == 'N' then
         match _info.ssl_mode
         | let _: SSLPreferred =>
           // SSLPreferred: fall back to plaintext cancel
-          _tcp_connection.buffer_until(lori.Streaming)
+          _tcp_connection.buffer_until(net.Streaming)
           _send_cancel_and_close()
         else
           // SSLRequired or unexpected: silently give up
@@ -85,15 +85,15 @@ actor _CancelSender is
     else
       _tcp_connection.close()
     end
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _on_tls_ready() =>
     // Reset buffer_until from 1 to streaming (same pattern as
     // _SessionSSLNegotiating)
-    _tcp_connection.buffer_until(lori.Streaming)
+    _tcp_connection.buffer_until(net.Streaming)
     _send_cancel_and_close()
 
-  fun ref _on_tls_failure(reason: lori.TLSFailureReason) =>
+  fun ref _on_tls_failure(reason: net.TLSFailureReason) =>
     // Fire-and-forget: TLS handshake failed, silently give up.
     // Lori follows this with _on_closed() (default no-op), so no
     // additional cleanup needed.

--- a/postgres/_query_no_query_in_flight.pony
+++ b/postgres/_query_no_query_in_flight.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 
 trait _QueryNoQueryInFlight is _QueryState
   """
@@ -422,10 +422,10 @@ class _QueryReady is _QueryNoQueryInFlight
           | let pl: _QueuedPipeline => pl.statement_timeout
           end
         match timeout
-        | let d: lori.TimerDuration =>
+        | let d: net.TimerDuration =>
           match \exhaustive\ s._connection().set_timer(d)
-          | let t: lori.TimerToken => li.statement_timer = t
-          | let _: lori.SetTimerError => None
+          | let t: net.TimerToken => li.statement_timer = t
+          | let _: net.SetTimerError => None
           end
         end
       end

--- a/postgres/_query_state.pony
+++ b/postgres/_query_state.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 
 interface _QueryState
   """

--- a/postgres/_session_state.pony
+++ b/postgres/_session_state.pony
@@ -1,6 +1,6 @@
 use "buffered"
 use "encode/base64"
-use lori = "lori"
+use net = "net"
 use "ssl/crypto"
 
 
@@ -43,7 +43,7 @@ interface _SessionState
     Called if the server requests we authenticate using a cleartext password.
     """
 
-  fun ref on_timer(s: Session ref, token: lori.TimerToken)
+  fun ref on_timer(s: Session ref, token: net.TimerToken)
     """
     A statement timeout timer fired. Like `cancel`, this should never be an
     illegal state — it should be silently ignored when not applicable.
@@ -89,10 +89,10 @@ interface _SessionState
 
   fun ref on_closed(s: Session ref)
     """
-    Called when lori reports that the TCP connection is closed. State
+    Called whennet reports that the TCP connection is closed. State
     implementations deliver the failure to the user through the callback
     appropriate for the current state and transition to `_SessionClosed`.
-    Implementations must be idempotent with user-initiated close — lori
+    Implementations must be idempotent with user-initiated close — net
     fires `_on_closed` after any `hard_close()`, including closes this
     session itself initiated.
     """
@@ -106,7 +106,7 @@ interface _SessionState
     s: Session ref,
     query: Query,
     receiver: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
     """
     Called when a client requests a query execution.
     """
@@ -116,7 +116,7 @@ interface _SessionState
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
     """
     Called when a client requests a named statement preparation.
     """
@@ -130,7 +130,7 @@ interface _SessionState
     s: Session ref,
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
     """
     Called when a client requests a COPY ... FROM STDIN operation.
     """
@@ -160,7 +160,7 @@ interface _SessionState
     s: Session ref,
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
     """
     Called when a client requests a COPY ... TO STDOUT operation.
     """
@@ -194,7 +194,7 @@ interface _SessionState
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
     """
     Called when a client requests a streaming query execution.
     """
@@ -213,7 +213,7 @@ interface _SessionState
     s: Session ref,
     queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
     """
     Called when a client requests a pipelined query execution.
     """
@@ -330,15 +330,15 @@ trait _ConnectableState is _UnconnectedState
 
   fun _start_ssl_negotiation(
     s: Session ref,
-    ctx: lori.SSLContext val,
+    ctx: net.SSLContext val,
     fallback_on_refusal: Bool)
   =>
-    // Set buffer_until(1) BEFORE sending SSLRequest so lori delivers exactly
+    // Set buffer_until(1) BEFORE sending SSLRequest sonet delivers exactly
     // one byte per _on_received call. Any MITM-injected bytes stay in
-    // lori's internal buffer, causing start_tls() to return
+    // net's internal buffer, causing start_tls() to return
     // StartTLSNotReady (CVE-2021-23222 mitigation).
-    match \exhaustive\ lori.MakeBufferSize(1)
-    | let e: lori.BufferSize => s._connection().buffer_until(e)
+    match \exhaustive\ net.MakeBufferSize(1)
+    | let e: net.BufferSize => s._connection().buffer_until(e)
     else
       _Unreachable()
     end
@@ -404,7 +404,7 @@ trait _ConnectedState is _NotConnectableState
   fun ref process_responses(s: Session ref) =>
     _ResponseMessageParser(s, readbuf())
 
-  fun ref on_timer(s: Session ref, token: lori.TimerToken) =>
+  fun ref on_timer(s: Session ref, token: net.TimerToken) =>
     None
 
   fun ref on_timer_failure(s: Session ref) =>
@@ -475,7 +475,7 @@ trait _UnconnectedState is (_NotAuthenticableState & _NotAuthenticated)
   fun ref process_responses(s: Session ref) =>
     None
 
-  fun ref on_timer(s: Session ref, token: lori.TimerToken) =>
+  fun ref on_timer(s: Session ref, token: net.TimerToken) =>
     None
 
   fun ref on_timer_failure(s: Session ref) =>

--- a/postgres/_test.pony
+++ b/postgres/_test.pony
@@ -1,5 +1,5 @@
 use "cli"
-use lori = "lori"
+use net = "net"
 use "pony_check"
 use "pony_test"
 
@@ -636,7 +636,7 @@ class \nodoc\ iso _TestAuthenticate is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         _AuthenticateTestNotify(h, true))
@@ -659,7 +659,7 @@ class \nodoc\ iso _TestAuthenticateFailure is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username,
           info.password + " " + info.password,
@@ -713,7 +713,7 @@ class \nodoc\ iso _TestConnect is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         _ConnectTestNotify(h, true))
@@ -738,7 +738,7 @@ class \nodoc\ iso _TestConnectFailure is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           host,
           info.port.reverse()),
         DatabaseConnectInfo(

--- a/postgres/_test_array.pony
+++ b/postgres/_test_array.pony
@@ -1,7 +1,7 @@
 use "cli"
 use "collections"
 use "constrained_types"
-use lori = "lori"
+use net = "net"
 use "pony_check"
 use "pony_test"
 
@@ -1115,7 +1115,7 @@ class \nodoc\ iso _TestIntegrationArraySelectBinary is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -1143,7 +1143,7 @@ class \nodoc\ iso _TestIntegrationArraySelectText is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -1167,7 +1167,7 @@ class \nodoc\ iso _TestIntegrationArrayRoundtrip is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -1191,7 +1191,7 @@ class \nodoc\ iso _TestIntegrationArrayEmpty is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -1215,7 +1215,7 @@ class \nodoc\ iso _TestIntegrationArrayNulls is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -1239,7 +1239,7 @@ class \nodoc\ iso _TestIntegrationArrayMultipleTypes is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_auth.pony
+++ b/postgres/_test_auth.pony
@@ -1,5 +1,5 @@
 use "encode/base64"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 // SCRAM-SHA-256 authentication unit tests
@@ -19,7 +19,7 @@ class \nodoc\ iso _TestSCRAMAuthenticationSuccess is UnitTest
 
     let listener =
       _SCRAMTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -43,7 +43,7 @@ class \nodoc\ iso _TestSCRAMUnsupportedMechanism is UnitTest
 
     let listener =
       _SCRAMUnsupportedTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -66,7 +66,7 @@ class \nodoc\ iso _TestSCRAMServerVerificationFailed is UnitTest
 
     let listener =
       _SCRAMTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -91,7 +91,7 @@ class \nodoc\ iso _TestSCRAMErrorDuringAuth is UnitTest
 
     let listener =
       _SCRAMErrorTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -115,7 +115,7 @@ class \nodoc\ iso _TestSCRAMServerSkipsSASLFinal is UnitTest
 
     let listener =
       _SCRAMSkipSASLFinalTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -140,7 +140,7 @@ class \nodoc\ iso _TestSCRAMDuplicateSASLContinue is UnitTest
 
     let listener =
       _SCRAMDuplicateSASLContinueTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -164,7 +164,7 @@ class \nodoc\ iso _TestSCRAMSASLFinalBeforeSASLContinue is UnitTest
 
     let listener =
       _SCRAMSASLFinalBeforeContinueTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -189,7 +189,7 @@ class \nodoc\ iso _TestSCRAMMalformedSASLFinal is UnitTest
 
     let listener =
       _SCRAMMalformedSASLFinalTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -214,7 +214,7 @@ class \nodoc\ iso _TestSCRAMNonceMismatch is UnitTest
 
     let listener =
       _SCRAMNonceMismatchTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -238,7 +238,7 @@ class \nodoc\ iso _TestSCRAMMalformedSASLContinue is UnitTest
 
     let listener =
       _SCRAMMalformedSASLContinueTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -261,7 +261,7 @@ class \nodoc\ iso _TestUnsupportedAuthentication is UnitTest
 
     let listener =
       _UnsupportedAuthenticationTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -269,14 +269,14 @@ class \nodoc\ iso _TestUnsupportedAuthentication is UnitTest
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _UnsupportedAuthenticationTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _UnsupportedAuthenticationTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -284,10 +284,10 @@ actor \nodoc\ _UnsupportedAuthenticationTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _UnsupportedAuthenticationTestServer =>
@@ -300,7 +300,7 @@ actor \nodoc\ _UnsupportedAuthenticationTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root), _host, _port),
+          net.TCPConnectAuth(_h.env.root), _host, _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
         _SCRAMFailureTestNotify(
           _h, UnsupportedAuthenticationMethod))
@@ -311,24 +311,24 @@ actor \nodoc\ _UnsupportedAuthenticationTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _UnsupportedAuthenticationTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that sends a KerberosV5 authentication request (type 2),
   which the driver does not support.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _received: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     if not _received then
       _received = true
       let msg =
@@ -336,7 +336,7 @@ actor \nodoc\ _UnsupportedAuthenticationTestServer
           2).bytes()
       _tcp_connection.send(msg)
     end
-    lori.KeepReading
+    net.KeepReading
 
 // Cleartext password authentication tests
 class \nodoc\ iso _TestCleartextAuthenticationSuccess is UnitTest
@@ -354,7 +354,7 @@ class \nodoc\ iso _TestCleartextAuthenticationSuccess is UnitTest
 
     let listener =
       _CleartextTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -378,7 +378,7 @@ class \nodoc\ iso _TestCleartextAuthenticationFailure is UnitTest
 
     let listener =
       _CleartextTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -387,19 +387,19 @@ class \nodoc\ iso _TestCleartextAuthenticationFailure is UnitTest
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _CleartextTestListener is lori.TCPListenerActor
+actor \nodoc\ _CleartextTestListener is net.TCPListenerActor
   """
   Listener for cleartext password authentication tests. Creates a mock
   cleartext server and connects a client session.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _send_error: Bool
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
@@ -409,10 +409,10 @@ actor \nodoc\ _CleartextTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _send_error = send_error
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CleartextTestServer =>
@@ -432,7 +432,7 @@ actor \nodoc\ _CleartextTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -445,32 +445,32 @@ actor \nodoc\ _CleartextTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _CleartextTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that performs a cleartext password authentication handshake.
   Receives a startup message, sends AuthenticationCleartextPassword, receives
   the password, then sends AuthenticationOk + ReadyForQuery (or ErrorResponse
   28P01 if _send_error is true).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _send_error: Bool
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32, send_error: Bool) =>
+  new create(auth: net.TCPServerAuth, fd: U32, send_error: Bool) =>
     _send_error = send_error
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -587,20 +587,20 @@ actor \nodoc\ _SCRAMFailureTestNotify is SessionStatusNotify
       _h.complete(false)
     end
 
-actor \nodoc\ _SCRAMTestListener is lori.TCPListenerActor
+actor \nodoc\ _SCRAMTestListener is net.TCPListenerActor
   """
   Listener for SCRAM-SHA-256 authentication tests. Creates a mock SCRAM
   server and connects a client session. Used by both the success test and
   the server verification failure test.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _send_wrong_signature: Bool
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
@@ -610,10 +610,10 @@ actor \nodoc\ _SCRAMTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _send_wrong_signature = send_wrong_signature
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMTestServer =>
@@ -634,7 +634,7 @@ actor \nodoc\ _SCRAMTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -646,7 +646,7 @@ actor \nodoc\ _SCRAMTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SCRAMTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that performs a SCRAM-SHA-256 authentication handshake.
   Optionally sends a wrong server signature to test verification failure.
@@ -655,7 +655,7 @@ actor \nodoc\ _SCRAMTestServer
   count. The expected client proof and server signature are computed using
   _ScramSha256 with the test password "postgres".
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   let _send_wrong_signature: Bool
   var _state: U8 = 0
@@ -663,25 +663,25 @@ actor \nodoc\ _SCRAMTestServer
   let _reader: _MockMessageReader = _MockMessageReader
 
   new create(
-    auth: lori.TCPServerAuth,
+    auth: net.TCPServerAuth,
     fd: U32,
     h: TestHelper,
     send_wrong_signature: Bool)
   =>
     _h = h
     _send_wrong_signature = send_wrong_signature
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -745,14 +745,14 @@ actor \nodoc\ _SCRAMTestServer
       end
     end
 
-actor \nodoc\ _SCRAMUnsupportedTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SCRAMUnsupportedTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -760,10 +760,10 @@ actor \nodoc\ _SCRAMUnsupportedTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMUnsupportedTestServer =>
@@ -776,7 +776,7 @@ actor \nodoc\ _SCRAMUnsupportedTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -789,23 +789,23 @@ actor \nodoc\ _SCRAMUnsupportedTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SCRAMUnsupportedTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that sends AuthSASL with only unsupported mechanisms.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     if not _authed then
       _authed = true
       let mechanisms: Array[String] val =
@@ -815,16 +815,16 @@ actor \nodoc\ _SCRAMUnsupportedTestServer
           mechanisms).bytes()
       _tcp_connection.send(sasl)
     end
-    lori.KeepReading
+    net.KeepReading
 
-actor \nodoc\ _SCRAMErrorTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SCRAMErrorTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -832,10 +832,10 @@ actor \nodoc\ _SCRAMErrorTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMErrorTestServer =>
@@ -847,7 +847,7 @@ actor \nodoc\ _SCRAMErrorTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -860,28 +860,28 @@ actor \nodoc\ _SCRAMErrorTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SCRAMErrorTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that starts a SCRAM exchange then sends an ErrorResponse
   with code 28P01 (invalid password) after receiving SASLInitialResponse.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -908,18 +908,18 @@ actor \nodoc\ _SCRAMErrorTestServer
       end
     end
 
-actor \nodoc\ _SCRAMSkipSASLFinalTestListener is lori.TCPListenerActor
+actor \nodoc\ _SCRAMSkipSASLFinalTestListener is net.TCPListenerActor
   """
   Listener for `_TestSCRAMServerSkipsSASLFinal`. Spawns a mock server that
   skips SASLFinal in the SCRAM exchange and connects a client session.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -927,10 +927,10 @@ actor \nodoc\ _SCRAMSkipSASLFinalTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMSkipSASLFinalTestServer =>
@@ -943,7 +943,7 @@ actor \nodoc\ _SCRAMSkipSASLFinalTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -956,32 +956,32 @@ actor \nodoc\ _SCRAMSkipSASLFinalTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SCRAMSkipSASLFinalTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that runs a SCRAM-SHA-256 exchange through
   AuthenticationSASLContinue, receives the client's SASLResponse, then
   skips SASLFinal entirely and sends AuthenticationOk + ReadyForQuery.
   The client must reject this as a protocol violation.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32, h: TestHelper) =>
+  new create(auth: net.TCPServerAuth, fd: U32, h: TestHelper) =>
     _h = h
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1028,18 +1028,18 @@ actor \nodoc\ _SCRAMSkipSASLFinalTestServer
       end
     end
 
-actor \nodoc\ _SCRAMDuplicateSASLContinueTestListener is lori.TCPListenerActor
+actor \nodoc\ _SCRAMDuplicateSASLContinueTestListener is net.TCPListenerActor
   """
   Listener for `_TestSCRAMDuplicateSASLContinue`. Spawns a mock server
   that sends two SASLContinue messages back-to-back.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1047,10 +1047,10 @@ actor \nodoc\ _SCRAMDuplicateSASLContinueTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMDuplicateSASLContinueTestServer =>
@@ -1064,7 +1064,7 @@ actor \nodoc\ _SCRAMDuplicateSASLContinueTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -1077,7 +1077,7 @@ actor \nodoc\ _SCRAMDuplicateSASLContinueTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SCRAMDuplicateSASLContinueTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that answers the client's SASLInitialResponse with two
   AuthenticationSASLContinue messages sent in a single TCP write. The
@@ -1085,25 +1085,25 @@ actor \nodoc\ _SCRAMDuplicateSASLContinueTestServer
   state; the second must be rejected by the duplicate-SASLContinue
   guard.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32, h: TestHelper) =>
+  new create(auth: net.TCPServerAuth, fd: U32, h: TestHelper) =>
     _h = h
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1139,18 +1139,18 @@ actor \nodoc\ _SCRAMDuplicateSASLContinueTestServer
     end
 
 actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestListener
-  is lori.TCPListenerActor
+  is net.TCPListenerActor
   """
   Listener for `_TestSCRAMSASLFinalBeforeSASLContinue`. Spawns a mock
   server that sends SASLFinal without ever sending SASLContinue.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1158,10 +1158,10 @@ actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMSASLFinalBeforeContinueTestServer =>
@@ -1175,7 +1175,7 @@ actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -1188,30 +1188,30 @@ actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestListener
     _h.complete(false)
 
 actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that answers the client's SASLInitialResponse with a
   SASLFinal directly, without a preceding SASLContinue. The SASLFinal
   body starts with "v=" but the client has no expected signature to
   compare against.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1238,19 +1238,19 @@ actor \nodoc\ _SCRAMSASLFinalBeforeContinueTestServer
       end
     end
 
-actor \nodoc\ _SCRAMMalformedSASLFinalTestListener is lori.TCPListenerActor
+actor \nodoc\ _SCRAMMalformedSASLFinalTestListener is net.TCPListenerActor
   """
   Listener for `_TestSCRAMMalformedSASLFinal`. Spawns a mock server that
   completes SCRAM up to SASLFinal, then sends a SASLFinal payload that
   does not begin with "v=".
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1258,10 +1258,10 @@ actor \nodoc\ _SCRAMMalformedSASLFinalTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMMalformedSASLFinalTestServer =>
@@ -1275,7 +1275,7 @@ actor \nodoc\ _SCRAMMalformedSASLFinalTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -1288,32 +1288,32 @@ actor \nodoc\ _SCRAMMalformedSASLFinalTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SCRAMMalformedSASLFinalTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that runs a SCRAM-SHA-256 exchange through
   AuthenticationSASLContinue, receives the client's SASLResponse, then
   sends an AuthenticationSASLFinal whose payload does not begin with
   "v=". The client must treat this as a protocol violation.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32, h: TestHelper) =>
+  new create(auth: net.TCPServerAuth, fd: U32, h: TestHelper) =>
     _h = h
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1353,19 +1353,19 @@ actor \nodoc\ _SCRAMMalformedSASLFinalTestServer
       end
     end
 
-actor \nodoc\ _SCRAMNonceMismatchTestListener is lori.TCPListenerActor
+actor \nodoc\ _SCRAMNonceMismatchTestListener is net.TCPListenerActor
   """
   Listener for `_TestSCRAMNonceMismatch`. Spawns a mock server that sends
   a SASLContinue whose combined nonce does not include the client's
   nonce.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1373,10 +1373,10 @@ actor \nodoc\ _SCRAMNonceMismatchTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMNonceMismatchTestServer =>
@@ -1389,7 +1389,7 @@ actor \nodoc\ _SCRAMNonceMismatchTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -1402,29 +1402,29 @@ actor \nodoc\ _SCRAMNonceMismatchTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SCRAMNonceMismatchTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server whose SASLContinue carries a combined nonce that does not
   begin with the client's nonce. The client's nonce-prefix check must
   reject as a protocol violation.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1457,18 +1457,18 @@ actor \nodoc\ _SCRAMNonceMismatchTestServer
     end
 
 actor \nodoc\ _SCRAMMalformedSASLContinueTestListener
-  is lori.TCPListenerActor
+  is net.TCPListenerActor
   """
   Listener for `_TestSCRAMMalformedSASLContinue`. Spawns a mock server
   that sends a SASLContinue whose iteration count is not a number.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1476,10 +1476,10 @@ actor \nodoc\ _SCRAMMalformedSASLContinueTestListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SCRAMMalformedSASLContinueTestServer =>
@@ -1493,7 +1493,7 @@ actor \nodoc\ _SCRAMMalformedSASLContinueTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -1506,32 +1506,32 @@ actor \nodoc\ _SCRAMMalformedSASLContinueTestListener
     _h.complete(false)
 
 actor \nodoc\ _SCRAMMalformedSASLContinueTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server whose SASLContinue uses the client's nonce (so the nonce
   prefix check passes) but has a non-numeric `i=` field. The client's
   outer `try`/`else` parse-failure path must fire
   `pg_session_connection_failed` with `ServerVerificationFailed`.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32, h: TestHelper) =>
+  new create(auth: net.TCPServerAuth, fd: U32, h: TestHelper) =>
     _h = h
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1810,7 +1810,7 @@ class \nodoc\ iso _TestConnectionFailedOnServerRejection is UnitTest
 
     let listener =
       _TooManyConnectionsTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -1818,14 +1818,14 @@ class \nodoc\ iso _TestConnectionFailedOnServerRejection is UnitTest
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _TooManyConnectionsTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _TooManyConnectionsTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1833,10 +1833,10 @@ actor \nodoc\ _TooManyConnectionsTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TooManyConnectionsTestServer =>
@@ -1849,7 +1849,7 @@ actor \nodoc\ _TooManyConnectionsTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -1861,26 +1861,26 @@ actor \nodoc\ _TooManyConnectionsTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _TooManyConnectionsTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that immediately rejects the startup message with SQLSTATE
   53300 (too_many_connections), closing the connection without requesting
   authentication.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _sent: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     if not _sent then
       match _reader.read_startup_message()
@@ -1895,7 +1895,7 @@ actor \nodoc\ _TooManyConnectionsTestServer
         _tcp_connection.close()
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 actor \nodoc\ _TooManyConnectionsTestNotify is SessionStatusNotify
   let _h: TestHelper

--- a/postgres/_test_auth_requirement.pony
+++ b/postgres/_test_auth_requirement.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 // AuthRequirement policy tests
@@ -47,7 +47,7 @@ class \nodoc\ iso _TestAuthRequireSCRAMRejectsAuthenticationOk is UnitTest
 
     let listener =
       _AuthMethodRejectedTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -74,7 +74,7 @@ class \nodoc\ iso _TestAuthRequireSCRAMRejectsCleartextPassword is UnitTest
 
     let listener =
       _AuthMethodRejectedTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -101,7 +101,7 @@ class \nodoc\ iso _TestAuthRequireSCRAMRejectsMD5Password is UnitTest
 
     let listener =
       _AuthMethodRejectedTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -116,22 +116,22 @@ primitive _AuthReplyMD5
 
 type _AuthReplyKind is (_AuthReplyOk | _AuthReplyCleartext | _AuthReplyMD5)
 
-actor \nodoc\ _AuthMethodRejectedTestListener is lori.TCPListenerActor
+actor \nodoc\ _AuthMethodRejectedTestListener is net.TCPListenerActor
   """
   Listener that stands up a mock server responding with a single non-SCRAM
   authentication message selected by `_AuthReplyKind`. The client session
   uses the default `AuthRequirement` (`AuthRequireSCRAM`), so any of these
   replies must be rejected.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _kind: _AuthReplyKind
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
@@ -141,10 +141,10 @@ actor \nodoc\ _AuthMethodRejectedTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _kind = kind
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _AuthMethodRejectedTestServer =>
@@ -156,7 +156,7 @@ actor \nodoc\ _AuthMethodRejectedTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
@@ -168,7 +168,7 @@ actor \nodoc\ _AuthMethodRejectedTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _AuthMethodRejectedTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that replies to the client's startup message with a single
   non-SCRAM authentication message and otherwise does nothing.
@@ -179,32 +179,32 @@ actor \nodoc\ _AuthMethodRejectedTestServer
   `Terminate` ('X') completes the "no-password-leak" action — the client
   finished cleanly without leaking credentials.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   let _kind: _AuthReplyKind
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
   new create(
-    auth: lori.TCPServerAuth,
+    auth: net.TCPServerAuth,
     fd: U32,
     h: TestHelper,
     kind: _AuthReplyKind)
   =>
     _h = h
     _kind = kind
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then

--- a/postgres/_test_cancel.pony
+++ b/postgres/_test_cancel.pony
@@ -1,5 +1,5 @@
 use "files"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestCancelQueryInFlight is UnitTest
@@ -17,7 +17,7 @@ class \nodoc\ iso _TestCancelQueryInFlight is UnitTest
 
     let listener =
       _CancelTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -51,16 +51,16 @@ actor \nodoc\ _CancelTestClient is (SessionStatusNotify & ResultReceiver)
   =>
     None
 
-actor \nodoc\ _CancelTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _CancelTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   var _connection_count: USize = 0
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -68,10 +68,10 @@ actor \nodoc\ _CancelTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CancelTestServer =>
@@ -86,7 +86,7 @@ actor \nodoc\ _CancelTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -100,38 +100,38 @@ actor \nodoc\ _CancelTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _CancelTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that handles two connections: the first is the main session
   (authenticates and becomes ready), the second is the cancel sender
   (verifies CancelRequest format and content).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   let _is_cancel_connection: Bool
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
   new create(
-    auth: lori.TCPServerAuth,
+    auth: net.TCPServerAuth,
     fd: U32,
     h: TestHelper,
     is_cancel: Bool)
   =>
     _h = h
     _is_cancel_connection = is_cancel
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _is_cancel_connection then
@@ -230,14 +230,14 @@ class \nodoc\ iso _TestSSLCancelQueryInFlight is UnitTest
 
     let client_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -245,7 +245,7 @@ class \nodoc\ iso _TestSSLCancelQueryInFlight is UnitTest
 
     let listener =
       _SSLCancelTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -255,33 +255,33 @@ class \nodoc\ iso _TestSSLCancelQueryInFlight is UnitTest
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _SSLCancelTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLCancelTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: lori.SSLContext val
-  let _server_sslctx: lori.SSLContext val
+  let _client_sslctx: net.SSLContext val
+  let _server_sslctx: net.SSLContext val
   var _connection_count: USize = 0
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: lori.SSLContext val,
-    server_sslctx: lori.SSLContext val)
+    client_sslctx: net.SSLContext val,
+    server_sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _client_sslctx = client_sslctx
     _server_sslctx = server_sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLCancelTestServer =>
@@ -300,7 +300,7 @@ actor \nodoc\ _SSLCancelTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLRequired(_client_sslctx)
@@ -315,14 +315,14 @@ actor \nodoc\ _SSLCancelTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SSLCancelTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock SSL server that handles two connections: the first is the main session
   (SSL negotiation + authenticate + ready), the second is the cancel sender
   (SSL negotiation + verify CancelRequest format and content).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
-  let _sslctx: lori.SSLContext val
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
+  let _sslctx: net.SSLContext val
   let _h: TestHelper
   let _is_cancel_connection: Bool
   var _ssl_started: Bool = false
@@ -330,8 +330,8 @@ actor \nodoc\ _SSLCancelTestServer
   let _reader: _MockMessageReader = _MockMessageReader
 
   new create(
-    auth: lori.TCPServerAuth,
-    sslctx: lori.SSLContext val,
+    auth: net.TCPServerAuth,
+    sslctx: net.SSLContext val,
     fd: U32,
     h: TestHelper,
     is_cancel: Bool)
@@ -339,18 +339,18 @@ actor \nodoc\ _SSLCancelTestServer
     _sslctx = sslctx
     _h = h
     _is_cancel_connection = is_cancel
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _ssl_started then
@@ -361,7 +361,7 @@ actor \nodoc\ _SSLCancelTestServer
         _tcp_connection.send(response)
         match \exhaustive\ _tcp_connection.start_tls(_sslctx)
         | None => _ssl_started = true
-        | let _: lori.StartTLSError =>
+        | let _: net.StartTLSError =>
           _tcp_connection.close()
         end
       end
@@ -455,7 +455,7 @@ class \nodoc\ iso _TestCancelPgSleep is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -528,7 +528,7 @@ class \nodoc\ iso _TestCancelSSLPgSleep is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -538,7 +538,7 @@ class \nodoc\ iso _TestCancelSSLPgSleep is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port,
           SSLRequired(sslctx)),

--- a/postgres/_test_composite.pony
+++ b/postgres/_test_composite.pony
@@ -1,6 +1,6 @@
 use "cli"
 use "collections"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 // ============================================================
@@ -2174,7 +2174,7 @@ class \nodoc\ iso
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -2202,7 +2202,7 @@ class \nodoc\ iso
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -2372,7 +2372,7 @@ actor \nodoc\ _CompositeRoundtripClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           _info.host,
           _info.port),
         DatabaseConnectInfo(
@@ -2493,7 +2493,7 @@ actor \nodoc\ _CompositeRoundtripClient is
       _session =
         Session(
           ServerConnectInfo(
-            lori.TCPConnectAuth(_h.env.root),
+            net.TCPConnectAuth(_h.env.root),
             _info.host,
             _info.port),
           DatabaseConnectInfo(

--- a/postgres/_test_connection_closed.pony
+++ b/postgres/_test_connection_closed.pony
@@ -1,5 +1,5 @@
 use "files"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 // Tests for peer-initiated TCP close. Each test puts the session in a
@@ -22,14 +22,14 @@ class \nodoc\ iso _TestRemoteCloseSSLNegotiating is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let listener =
       _RemoteCloseSSLNegotiatingListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -66,29 +66,29 @@ actor \nodoc\ _RemoteCloseSSLNegotiatingNotify is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteCloseSSLNegotiatingListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteCloseSSLNegotiatingListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: lori.SSLContext val
+  let _sslctx: net.SSLContext val
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: lori.SSLContext val)
+    sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _sslctx = sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterSSLRequestServer =>
@@ -100,7 +100,7 @@ actor \nodoc\ _RemoteCloseSSLNegotiatingListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLRequired(_sslctx)),
@@ -113,32 +113,32 @@ actor \nodoc\ _RemoteCloseSSLNegotiatingListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _RemoteCloseAfterSSLRequestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Reads the client's SSLRequest, then closes without responding.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _closed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
-    if _closed then return lori.KeepReading end
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
+    if _closed then return net.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
       _closed = true
       _tcp_connection.close()
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestRemoteClosePreAuth is UnitTest
   """
@@ -155,7 +155,7 @@ class \nodoc\ iso _TestRemoteClosePreAuth is UnitTest
 
     let listener =
       _RemoteClosePreAuthListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -188,15 +188,15 @@ actor \nodoc\ _RemoteClosePreAuthNotify is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteClosePreAuthListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteClosePreAuthListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -204,10 +204,10 @@ actor \nodoc\ _RemoteClosePreAuthListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterStartupServer =>
@@ -219,7 +219,7 @@ actor \nodoc\ _RemoteClosePreAuthListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root), _host, _port),
+          net.TCPConnectAuth(_h.env.root), _host, _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
         _RemoteClosePreAuthNotify(_h))
     _h.dispose_when_done(session)
@@ -229,32 +229,32 @@ actor \nodoc\ _RemoteClosePreAuthListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _RemoteCloseAfterStartupServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Reads the client's StartupMessage, then closes without responding.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _closed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
-    if _closed then return lori.KeepReading end
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
+    if _closed then return net.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
       _closed = true
       _tcp_connection.close()
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseSCRAM is UnitTest
   """
@@ -272,7 +272,7 @@ class \nodoc\ iso _TestRemoteCloseSCRAM is UnitTest
 
     let listener =
       _RemoteCloseSCRAMListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -305,15 +305,15 @@ actor \nodoc\ _RemoteCloseSCRAMNotify is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteCloseSCRAMListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteCloseSCRAMListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -321,10 +321,10 @@ actor \nodoc\ _RemoteCloseSCRAMListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseSCRAMServer =>
@@ -336,7 +336,7 @@ actor \nodoc\ _RemoteCloseSCRAMListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root), _host, _port),
+          net.TCPConnectAuth(_h.env.root), _host, _port),
         DatabaseConnectInfo("postgres", "postgres", "postgres"),
         _RemoteCloseSCRAMNotify(_h))
     _h.dispose_when_done(session)
@@ -346,25 +346,25 @@ actor \nodoc\ _RemoteCloseSCRAMListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _RemoteCloseSCRAMServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Starts a SASL SCRAM-SHA-256 exchange, then closes after the client's
   SASLInitialResponse arrives (session state: _SessionSCRAMAuthenticating).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _phase: USize = 0
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     if _phase == 0 then
       match _reader.read_startup_message()
@@ -382,7 +382,7 @@ actor \nodoc\ _RemoteCloseSCRAMServer
         _tcp_connection.close()
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseLoggedInIdle is UnitTest
   """
@@ -398,7 +398,7 @@ class \nodoc\ iso _TestRemoteCloseLoggedInIdle is UnitTest
 
     let listener =
       _RemoteCloseLoggedInIdleListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -427,15 +427,15 @@ actor \nodoc\ _RemoteCloseLoggedInIdleNotify is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteCloseLoggedInIdleListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteCloseLoggedInIdleListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -443,10 +443,10 @@ actor \nodoc\ _RemoteCloseLoggedInIdleListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseLoggedInIdleServer =>
@@ -458,7 +458,7 @@ actor \nodoc\ _RemoteCloseLoggedInIdleListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -471,25 +471,25 @@ actor \nodoc\ _RemoteCloseLoggedInIdleListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _RemoteCloseLoggedInIdleServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Authenticates the client, signals ReadyForQuery, then closes.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _closed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
-    if _closed then return lori.KeepReading end
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
+    if _closed then return net.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -500,7 +500,7 @@ actor \nodoc\ _RemoteCloseLoggedInIdleServer
         _IncomingReadyForQueryTestMessage('I').bytes())
       _tcp_connection.close()
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseLoggedInInFlight is UnitTest
   """
@@ -516,7 +516,7 @@ class \nodoc\ iso _TestRemoteCloseLoggedInInFlight is UnitTest
 
     let listener =
       _RemoteCloseLoggedInInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -576,15 +576,15 @@ actor \nodoc\ _RemoteCloseLoggedInInFlightClient is
     _h.complete(true)
 
 actor \nodoc\ _RemoteCloseLoggedInInFlightListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -592,10 +592,10 @@ actor \nodoc\ _RemoteCloseLoggedInInFlightListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -607,7 +607,7 @@ actor \nodoc\ _RemoteCloseLoggedInInFlightListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -620,26 +620,26 @@ actor \nodoc\ _RemoteCloseLoggedInInFlightListener
     _h.complete(false)
 
 actor \nodoc\ _RemoteCloseAfterQueryServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Authenticates the client, waits for a message after ReadyForQuery,
   then closes — putting the client in `_SessionLoggedIn` with a query in
   flight.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _authed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -656,7 +656,7 @@ actor \nodoc\ _RemoteCloseAfterQueryServer
         _tcp_connection.close()
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseLoggedInPipeline is UnitTest
   """
@@ -673,7 +673,7 @@ class \nodoc\ iso _TestRemoteCloseLoggedInPipeline is UnitTest
 
     let listener =
       _RemoteCloseLoggedInPipelineListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -744,15 +744,15 @@ actor \nodoc\ _RemoteCloseLoggedInPipelineClient is
     _h.complete(true)
 
 actor \nodoc\ _RemoteCloseLoggedInPipelineListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -760,10 +760,10 @@ actor \nodoc\ _RemoteCloseLoggedInPipelineListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -778,7 +778,7 @@ actor \nodoc\ _RemoteCloseLoggedInPipelineListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -805,7 +805,7 @@ class \nodoc\ iso _TestRemoteCloseExtendedQueryInFlight is UnitTest
 
     let listener =
       _RemoteCloseExtendedQueryListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -853,15 +853,15 @@ actor \nodoc\ _RemoteCloseExtendedQueryClient is
     _h.complete(true)
 
 actor \nodoc\ _RemoteCloseExtendedQueryListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -869,10 +869,10 @@ actor \nodoc\ _RemoteCloseExtendedQueryListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -884,7 +884,7 @@ actor \nodoc\ _RemoteCloseExtendedQueryListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -910,7 +910,7 @@ class \nodoc\ iso _TestRemoteClosePrepareInFlight is UnitTest
 
     let listener =
       _RemoteClosePrepareListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -955,15 +955,15 @@ actor \nodoc\ _RemoteClosePrepareClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteClosePrepareListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteClosePrepareListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -971,10 +971,10 @@ actor \nodoc\ _RemoteClosePrepareListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -986,7 +986,7 @@ actor \nodoc\ _RemoteClosePrepareListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1013,7 +1013,7 @@ class \nodoc\ iso _TestRemoteCloseCopyInInFlight is UnitTest
 
     let listener =
       _RemoteCloseCopyInListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1060,15 +1060,15 @@ actor \nodoc\ _RemoteCloseCopyInClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteCloseCopyInListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteCloseCopyInListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1076,10 +1076,10 @@ actor \nodoc\ _RemoteCloseCopyInListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -1091,7 +1091,7 @@ actor \nodoc\ _RemoteCloseCopyInListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1118,7 +1118,7 @@ class \nodoc\ iso _TestRemoteCloseCopyOutInFlight is UnitTest
 
     let listener =
       _RemoteCloseCopyOutListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1165,15 +1165,15 @@ actor \nodoc\ _RemoteCloseCopyOutClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteCloseCopyOutListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteCloseCopyOutListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1181,10 +1181,10 @@ actor \nodoc\ _RemoteCloseCopyOutListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -1196,7 +1196,7 @@ actor \nodoc\ _RemoteCloseCopyOutListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1223,7 +1223,7 @@ class \nodoc\ iso _TestRemoteCloseStreamInFlight is UnitTest
 
     let listener =
       _RemoteCloseStreamListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1273,15 +1273,15 @@ actor \nodoc\ _RemoteCloseStreamClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _RemoteCloseStreamListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _RemoteCloseStreamListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1289,10 +1289,10 @@ actor \nodoc\ _RemoteCloseStreamListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -1304,7 +1304,7 @@ actor \nodoc\ _RemoteCloseStreamListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1334,7 +1334,7 @@ class \nodoc\ iso _TestRemoteClosePostAuthPreReady is UnitTest
 
     let listener =
       _RemoteClosePostAuthPreReadyListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1364,15 +1364,15 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyNotify is SessionStatusNotify
     _h.complete(true)
 
 actor \nodoc\ _RemoteClosePostAuthPreReadyListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1380,10 +1380,10 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteClosePostAuthPreReadyServer =>
@@ -1396,7 +1396,7 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1409,27 +1409,27 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyListener
     _h.complete(false)
 
 actor \nodoc\ _RemoteClosePostAuthPreReadyServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Reads the client's StartupMessage, sends `AuthenticationOk` (no
   `ReadyForQuery`), then closes. Leaves the client in `_SessionLoggedIn`
   with `query_state = _QueryNotReady`.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _closed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
-    if _closed then return lori.KeepReading end
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
+    if _closed then return net.KeepReading end
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -1438,7 +1438,7 @@ actor \nodoc\ _RemoteClosePostAuthPreReadyServer
         _IncomingAuthenticationOkTestMessage.bytes())
       _tcp_connection.close()
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseCloseStatementInFlight is UnitTest
   """
@@ -1456,7 +1456,7 @@ class \nodoc\ iso _TestRemoteCloseCloseStatementInFlight is UnitTest
 
     let listener =
       _RemoteCloseCloseStatementListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1487,15 +1487,15 @@ actor \nodoc\ _RemoteCloseCloseStatementClient is SessionStatusNotify
     _h.complete(true)
 
 actor \nodoc\ _RemoteCloseCloseStatementListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1503,10 +1503,10 @@ actor \nodoc\ _RemoteCloseCloseStatementListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterQueryServer =>
@@ -1518,7 +1518,7 @@ actor \nodoc\ _RemoteCloseCloseStatementListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1549,7 +1549,7 @@ class \nodoc\ iso _TestRemoteCloseAfterErrorResponse is UnitTest
 
     let listener =
       _RemoteCloseAfterErrorResponseListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1614,15 +1614,15 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseClient is
     _h.complete(true)
 
 actor \nodoc\ _RemoteCloseAfterErrorResponseListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1630,10 +1630,10 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterErrorResponseServer =>
@@ -1646,7 +1646,7 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1659,28 +1659,28 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseListener
     _h.complete(false)
 
 actor \nodoc\ _RemoteCloseAfterErrorResponseServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Authenticates the client, waits for a query, then responds with
   `ErrorResponse` and closes WITHOUT sending `ReadyForQuery`. Forces the
   `on_closed`/`drain_in_flight` double-delivery risk.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _authed: Bool = false
   var _closed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
-    if _closed then return lori.KeepReading end
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
+    if _closed then return net.KeepReading end
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -1701,7 +1701,7 @@ actor \nodoc\ _RemoteCloseAfterErrorResponseServer
         _tcp_connection.close()
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestRemoteCloseSSLNegotiatingPreferred is UnitTest
   """
@@ -1720,14 +1720,14 @@ class \nodoc\ iso _TestRemoteCloseSSLNegotiatingPreferred is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let listener =
       _RemoteCloseSSLNegotiatingPreferredListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -1736,29 +1736,29 @@ class \nodoc\ iso _TestRemoteCloseSSLNegotiatingPreferred is UnitTest
     h.long_test(5_000_000_000)
 
 actor \nodoc\ _RemoteCloseSSLNegotiatingPreferredListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: lori.SSLContext val
+  let _sslctx: net.SSLContext val
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: lori.SSLContext val)
+    sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _sslctx = sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _RemoteCloseAfterSSLRequestServer =>
@@ -1771,7 +1771,7 @@ actor \nodoc\ _RemoteCloseSSLNegotiatingPreferredListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLPreferred(_sslctx)),

--- a/postgres/_test_connection_timeout.pony
+++ b/postgres/_test_connection_timeout.pony
@@ -1,5 +1,5 @@
 use "constrained_types"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestConnectionTimeoutFires is UnitTest
@@ -12,12 +12,12 @@ class \nodoc\ iso _TestConnectionTimeoutFires is UnitTest
     "ConnectionTimeout/Fires"
 
   fun apply(h: TestHelper) =>
-    match \exhaustive\ lori.MakeConnectionTimeout(100)
-    | let ct: lori.ConnectionTimeout =>
+    match \exhaustive\ net.MakeConnectionTimeout(100)
+    | let ct: net.ConnectionTimeout =>
       let session =
         Session(
           ServerConnectInfo(
-            lori.TCPConnectAuth(h.env.root),
+            net.TCPConnectAuth(h.env.root),
             "192.0.2.1",
             "9999"
             where connection_timeout' = ct),

--- a/postgres/_test_copy_in.pony
+++ b/postgres/_test_copy_in.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestCopyInSuccess is UnitTest
@@ -16,7 +16,7 @@ class \nodoc\ iso _TestCopyInSuccess is UnitTest
 
     let listener =
       _CopyInSuccessTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -75,14 +75,14 @@ actor \nodoc\ _CopyInSuccessTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _CopyInSuccessTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _CopyInSuccessTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -90,10 +90,10 @@ actor \nodoc\ _CopyInSuccessTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyInSuccessTestServer =>
@@ -106,7 +106,7 @@ actor \nodoc\ _CopyInSuccessTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -120,29 +120,29 @@ actor \nodoc\ _CopyInSuccessTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _CopyInSuccessTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds to a COPY query with
   CopyInResponse, expects CopyData messages followed by CopyDone,
   then sends CommandComplete("COPY 2") + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -204,7 +204,7 @@ class \nodoc\ iso _TestCopyInAbort is UnitTest
 
     let listener =
       _CopyInAbortTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -256,14 +256,14 @@ actor \nodoc\ _CopyInAbortTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _CopyInAbortTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _CopyInAbortTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -271,10 +271,10 @@ actor \nodoc\ _CopyInAbortTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyInAbortTestServer =>
@@ -287,7 +287,7 @@ actor \nodoc\ _CopyInAbortTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -301,28 +301,28 @@ actor \nodoc\ _CopyInAbortTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _CopyInAbortTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds with CopyInResponse, then
   responds to CopyFail with ErrorResponse + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -385,7 +385,7 @@ class \nodoc\ iso _TestCopyInServerError is UnitTest
 
     let listener =
       _CopyInServerErrorTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -454,15 +454,15 @@ actor \nodoc\ _CopyInServerErrorTestClient is
     _h.complete(success)
 
 actor \nodoc\ _CopyInServerErrorTestListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener =
-    lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener =
+    net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -470,11 +470,11 @@ actor \nodoc\ _CopyInServerErrorTestListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
+    _server_auth = net.TCPServerAuth(listen_auth)
     _tcp_listener =
-      lori.TCPListener(listen_auth, host, port, this)
+      net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32)
@@ -489,7 +489,7 @@ actor \nodoc\ _CopyInServerErrorTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -503,37 +503,37 @@ actor \nodoc\ _CopyInServerErrorTestListener
     _h.complete(false)
 
 actor \nodoc\ _CopyInServerErrorTestServer
-  is (lori.TCPConnectionActor
-    & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor
+    & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds with CopyInResponse,
   then responds to CopyData with ErrorResponse + ReadyForQuery
   (simulating a server-side error during COPY). Follow-up queries
   get normal responses.
   """
-  var _tcp_connection: lori.TCPConnection =
-    lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection =
+    net.TCPConnection.none()
   var _state: U8 = 0
   var _copy_error_sent: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
+  new create(auth: net.TCPServerAuth, fd: U32) =>
     _tcp_connection =
-      lori.TCPConnection.server(auth, fd, this, this)
+      net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
   fun ref _on_received(
     data: Array[U8] iso)
-    : lori.ReadAction
+    : net.ReadAction
   =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -626,7 +626,7 @@ class \nodoc\ iso _TestCopyInShutdownDrainsCopyQueue
 
     let listener =
       _CopyInShutdownTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -677,15 +677,15 @@ actor \nodoc\ _CopyInShutdownTestClient is
     end
 
 actor \nodoc\ _CopyInShutdownTestListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener =
-    lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener =
+    net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -693,11 +693,11 @@ actor \nodoc\ _CopyInShutdownTestListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
+    _server_auth = net.TCPServerAuth(listen_auth)
     _tcp_listener =
-      lori.TCPListener(listen_auth, host, port, this)
+      net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
@@ -710,7 +710,7 @@ actor \nodoc\ _CopyInShutdownTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -737,7 +737,7 @@ class \nodoc\ iso _TestCopyInAfterSessionClosed is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_copy_out.pony
+++ b/postgres/_test_copy_out.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestCopyOutSuccess is UnitTest
@@ -16,7 +16,7 @@ class \nodoc\ iso _TestCopyOutSuccess is UnitTest
 
     let listener =
       _CopyOutSuccessTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -68,14 +68,14 @@ actor \nodoc\ _CopyOutSuccessTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _CopyOutSuccessTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _CopyOutSuccessTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -83,10 +83,10 @@ actor \nodoc\ _CopyOutSuccessTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyOutSuccessTestServer =>
@@ -98,7 +98,7 @@ actor \nodoc\ _CopyOutSuccessTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -111,29 +111,29 @@ actor \nodoc\ _CopyOutSuccessTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _CopyOutSuccessTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds to a COPY query with
   CopyOutResponse, sends two CopyData messages, then CopyDone +
   CommandComplete("COPY 2") + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -185,7 +185,7 @@ class \nodoc\ iso _TestCopyOutEmpty is UnitTest
 
     let listener =
       _CopyOutEmptyTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -237,14 +237,14 @@ actor \nodoc\ _CopyOutEmptyTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _CopyOutEmptyTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _CopyOutEmptyTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -252,10 +252,10 @@ actor \nodoc\ _CopyOutEmptyTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyOutEmptyTestServer =>
@@ -267,7 +267,7 @@ actor \nodoc\ _CopyOutEmptyTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -280,29 +280,29 @@ actor \nodoc\ _CopyOutEmptyTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _CopyOutEmptyTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds with CopyOutResponse, then
   immediately sends CopyDone + CommandComplete("COPY 0") + ReadyForQuery
   (zero rows exported).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -347,7 +347,7 @@ class \nodoc\ iso _TestCopyOutServerError is UnitTest
 
     let listener =
       _CopyOutServerErrorTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -411,14 +411,14 @@ actor \nodoc\ _CopyOutServerErrorTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _CopyOutServerErrorTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _CopyOutServerErrorTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -426,10 +426,10 @@ actor \nodoc\ _CopyOutServerErrorTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _CopyOutServerErrorTestServer =>
@@ -441,7 +441,7 @@ actor \nodoc\ _CopyOutServerErrorTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -454,29 +454,29 @@ actor \nodoc\ _CopyOutServerErrorTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _CopyOutServerErrorTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds with CopyOutResponse, sends one
   CopyData, then ErrorResponse + ReadyForQuery (simulating a server-side
   error during COPY). Follow-up queries get normal responses.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -548,7 +548,7 @@ class \nodoc\ iso _TestCopyOutShutdownDrainsCopyQueue is UnitTest
 
     let listener =
       _CopyOutShutdownTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -599,14 +599,14 @@ actor \nodoc\ _CopyOutShutdownTestClient is
       _h.complete(false)
     end
 
-actor \nodoc\ _CopyOutShutdownTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _CopyOutShutdownTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -614,10 +614,10 @@ actor \nodoc\ _CopyOutShutdownTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
@@ -629,7 +629,7 @@ actor \nodoc\ _CopyOutShutdownTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -655,7 +655,7 @@ class \nodoc\ iso _TestCopyOutAfterSessionClosed is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -717,7 +717,7 @@ class \nodoc\ iso _TestCopyOutExport is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_md5.pony
+++ b/postgres/_test_md5.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestMD5Authenticate is UnitTest
@@ -17,7 +17,7 @@ class \nodoc\ iso _TestMD5Authenticate is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port
           where auth_requirement' = AllowAnyAuth),
@@ -44,7 +44,7 @@ class \nodoc\ iso _TestMD5AuthenticateFailure is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port
           where auth_requirement' = AllowAnyAuth),
@@ -73,7 +73,7 @@ class \nodoc\ iso _TestMD5QueryResults is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port
           where auth_requirement' = AllowAnyAuth),

--- a/postgres/_test_notice.pony
+++ b/postgres/_test_notice.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestNoticeDelivery is UnitTest
@@ -16,7 +16,7 @@ class \nodoc\ iso _TestNoticeDelivery is UnitTest
 
     let listener =
       _NoticeTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _NoticeDeliveryClient(h),
@@ -107,7 +107,7 @@ class \nodoc\ iso _TestNoticeDuringDataRows is UnitTest
 
     let listener =
       _NoticeMidQueryTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _NoticeDuringDataRowsClient(h),
@@ -181,19 +181,19 @@ actor \nodoc\ _NoticeDuringDataRowsClient
     _h.complete(false)
 
 // Shared mock server infrastructure for notice tests
-actor \nodoc\ _NoticeTestListener is lori.TCPListenerActor
+actor \nodoc\ _NoticeTestListener is net.TCPListenerActor
   """
   Mock server that authenticates, waits for a query, then responds with
   CommandComplete + NoticeResponse + ReadyForQuery.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _notify: (SessionStatusNotify & ResultReceiver)
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     notify: (SessionStatusNotify & ResultReceiver),
@@ -203,10 +203,10 @@ actor \nodoc\ _NoticeTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _notify = notify
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NoticeTestServer =>
@@ -218,7 +218,7 @@ actor \nodoc\ _NoticeTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -231,28 +231,28 @@ actor \nodoc\ _NoticeTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _NoticeTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then on first query responds with
   CommandComplete + NoticeResponse + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -278,18 +278,18 @@ actor \nodoc\ _NoticeTestServer
       end
     end
 
-actor \nodoc\ _NoticeMidQueryTestListener is lori.TCPListenerActor
+actor \nodoc\ _NoticeMidQueryTestListener is net.TCPListenerActor
   """
   Mock server listener for the mid-query notice test.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _notify: (SessionStatusNotify & ResultReceiver)
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     notify: (SessionStatusNotify & ResultReceiver),
@@ -299,10 +299,10 @@ actor \nodoc\ _NoticeMidQueryTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _notify = notify
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NoticeMidQueryTestServer =>
@@ -314,7 +314,7 @@ actor \nodoc\ _NoticeMidQueryTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -327,29 +327,29 @@ actor \nodoc\ _NoticeMidQueryTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _NoticeMidQueryTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then on first query responds with
   RowDescription + DataRow + NoticeResponse + DataRow +
   CommandComplete + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -421,7 +421,7 @@ actor \nodoc\ _NoticeDropIfExistsClient
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_notification.pony
+++ b/postgres/_test_notification.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestNotificationDelivery is UnitTest
@@ -16,7 +16,7 @@ class \nodoc\ iso _TestNotificationDelivery is UnitTest
 
     let listener =
       _NotificationTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _NotificationDeliveryClient(h),
@@ -115,7 +115,7 @@ class \nodoc\ iso _TestNotificationDuringDataRows is UnitTest
 
     let listener =
       _NotificationMidQueryTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _NotificationDuringDataRowsClient(h),
@@ -196,20 +196,20 @@ actor \nodoc\ _NotificationDuringDataRowsClient
     _h.complete(false)
 
 // Shared mock server infrastructure for notification tests
-actor \nodoc\ _NotificationTestListener is lori.TCPListenerActor
+actor \nodoc\ _NotificationTestListener is net.TCPListenerActor
   """
   Mock server that authenticates, waits for a query, then responds
   with CommandComplete + NotificationResponse + ReadyForQuery.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _notify: (SessionStatusNotify & ResultReceiver)
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     notify: (SessionStatusNotify & ResultReceiver),
@@ -219,10 +219,10 @@ actor \nodoc\ _NotificationTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _notify = notify
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NotificationTestServer =>
@@ -235,7 +235,7 @@ actor \nodoc\ _NotificationTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -249,28 +249,28 @@ actor \nodoc\ _NotificationTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _NotificationTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then on first query responds with
   CommandComplete + NotificationResponse + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -303,19 +303,19 @@ actor \nodoc\ _NotificationTestServer
     end
 
 actor \nodoc\ _NotificationMidQueryTestListener
-  is lori.TCPListenerActor
+  is net.TCPListenerActor
   """
   Mock server listener for the mid-query notification test.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _notify: (SessionStatusNotify & ResultReceiver)
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     notify: (SessionStatusNotify & ResultReceiver),
@@ -325,10 +325,10 @@ actor \nodoc\ _NotificationMidQueryTestListener
     _port = port
     _h = h
     _notify = notify
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _NotificationMidQueryTestServer =>
@@ -341,7 +341,7 @@ actor \nodoc\ _NotificationMidQueryTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -355,29 +355,29 @@ actor \nodoc\ _NotificationMidQueryTestListener
     _h.complete(false)
 
 actor \nodoc\ _NotificationMidQueryTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then on first query responds with
   RowDescription + DataRow + NotificationResponse + DataRow +
   CommandComplete + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -463,7 +463,7 @@ actor \nodoc\ _ListenNotifyClient
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_parameter_status.pony
+++ b/postgres/_test_parameter_status.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestParameterStatusDelivery is UnitTest
@@ -16,7 +16,7 @@ class \nodoc\ iso _TestParameterStatusDelivery is UnitTest
 
     let listener =
       _ParameterStatusTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _ParameterStatusDeliveryClient(h),
@@ -106,7 +106,7 @@ class \nodoc\ iso _TestParameterStatusDuringDataRows is UnitTest
 
     let listener =
       _ParameterStatusMidQueryTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _ParameterStatusDuringDataRowsClient(h),
@@ -187,20 +187,20 @@ actor \nodoc\ _ParameterStatusDuringDataRowsClient
     _h.complete(false)
 
 // Shared mock server infrastructure for parameter status tests
-actor \nodoc\ _ParameterStatusTestListener is lori.TCPListenerActor
+actor \nodoc\ _ParameterStatusTestListener is net.TCPListenerActor
   """
   Mock server that authenticates, waits for a query, then responds
   with CommandComplete + ParameterStatus + ReadyForQuery.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _notify: (SessionStatusNotify & ResultReceiver)
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     notify: (SessionStatusNotify & ResultReceiver),
@@ -210,10 +210,10 @@ actor \nodoc\ _ParameterStatusTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _notify = notify
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ParameterStatusTestServer =>
@@ -226,7 +226,7 @@ actor \nodoc\ _ParameterStatusTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -240,28 +240,28 @@ actor \nodoc\ _ParameterStatusTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _ParameterStatusTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then on first query responds with
   CommandComplete + ParameterStatus + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -294,19 +294,19 @@ actor \nodoc\ _ParameterStatusTestServer
     end
 
 actor \nodoc\ _ParameterStatusMidQueryTestListener
-  is lori.TCPListenerActor
+  is net.TCPListenerActor
   """
   Mock server listener for the mid-query parameter status test.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _notify: (SessionStatusNotify & ResultReceiver)
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     notify: (SessionStatusNotify & ResultReceiver),
@@ -316,10 +316,10 @@ actor \nodoc\ _ParameterStatusMidQueryTestListener
     _port = port
     _h = h
     _notify = notify
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ParameterStatusMidQueryTestServer =>
@@ -332,7 +332,7 @@ actor \nodoc\ _ParameterStatusMidQueryTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -346,29 +346,29 @@ actor \nodoc\ _ParameterStatusMidQueryTestListener
     _h.complete(false)
 
 actor \nodoc\ _ParameterStatusMidQueryTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then on first query responds with
   RowDescription + DataRow + ParameterStatus + DataRow +
   CommandComplete + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -452,7 +452,7 @@ actor \nodoc\ _ParameterStatusStartupClient is SessionStatusNotify
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -527,7 +527,7 @@ actor \nodoc\ _ParameterStatusSetClient
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_pipeline.pony
+++ b/postgres/_test_pipeline.pony
@@ -1,5 +1,5 @@
 use "collections"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestPipelineSuccess is UnitTest
@@ -16,7 +16,7 @@ class \nodoc\ iso _TestPipelineSuccess is UnitTest
 
     let listener =
       _PipelineSuccessTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -88,15 +88,15 @@ actor \nodoc\ _PipelineSuccessTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _PipelineSuccessTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PipelineSuccessTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -104,10 +104,10 @@ actor \nodoc\ _PipelineSuccessTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineSuccessTestServer =>
@@ -119,7 +119,7 @@ actor \nodoc\ _PipelineSuccessTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -133,30 +133,30 @@ actor \nodoc\ _PipelineSuccessTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PipelineSuccessTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then responds to 3 pipelined query cycles.
   Each cycle: Parse+Bind+Describe+Execute+Sync from client; server sends
   RowDescription+DataRow+CommandComplete+ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   var _query_count: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -216,7 +216,7 @@ class \nodoc\ iso _TestPipelineWithFailure is UnitTest
 
     let listener =
       _PipelineWithFailureTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -292,15 +292,15 @@ actor \nodoc\ _PipelineWithFailureTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _PipelineWithFailureTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PipelineWithFailureTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -308,10 +308,10 @@ actor \nodoc\ _PipelineWithFailureTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineWithFailureTestServer =>
@@ -323,7 +323,7 @@ actor \nodoc\ _PipelineWithFailureTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -337,29 +337,29 @@ actor \nodoc\ _PipelineWithFailureTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PipelineWithFailureTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then processes 3 pipelined query cycles.
   Query 1 succeeds, query 2 returns ErrorResponse, query 3 succeeds.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   var _sync_count: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -432,7 +432,7 @@ class \nodoc\ iso _TestPipelineEmpty is UnitTest
 
     let listener =
       _PipelineEmptyTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -496,15 +496,15 @@ actor \nodoc\ _PipelineEmptyTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _PipelineEmptyTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PipelineEmptyTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -512,10 +512,10 @@ actor \nodoc\ _PipelineEmptyTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineEmptyTestServer =>
@@ -527,7 +527,7 @@ actor \nodoc\ _PipelineEmptyTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -541,24 +541,24 @@ actor \nodoc\ _PipelineEmptyTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PipelineEmptyTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates and sends ReadyForQuery. The empty pipeline
   dispatches without sending any messages.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -567,7 +567,7 @@ actor \nodoc\ _PipelineEmptyTestServer
       _tcp_connection.send(auth_ok)
       _tcp_connection.send(ready)
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestPipelineSingleQuery is UnitTest
   """
@@ -582,7 +582,7 @@ class \nodoc\ iso _TestPipelineSingleQuery is UnitTest
 
     let listener =
       _PipelineSingleQueryTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -651,15 +651,15 @@ actor \nodoc\ _PipelineSingleQueryTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _PipelineSingleQueryTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PipelineSingleQueryTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -667,10 +667,10 @@ actor \nodoc\ _PipelineSingleQueryTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineSuccessTestServer =>
@@ -682,7 +682,7 @@ actor \nodoc\ _PipelineSingleQueryTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -710,7 +710,7 @@ class \nodoc\ iso _TestPipelineShutdownDrainsQueue is UnitTest
 
     let listener =
       _PipelineShutdownDrainsQueueTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -780,15 +780,15 @@ actor \nodoc\ _PipelineShutdownDrainsQueueTestClient is
     end
 
 actor \nodoc\ _PipelineShutdownDrainsQueueTestListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -796,10 +796,10 @@ actor \nodoc\ _PipelineShutdownDrainsQueueTestListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
@@ -811,7 +811,7 @@ actor \nodoc\ _PipelineShutdownDrainsQueueTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -839,7 +839,7 @@ class \nodoc\ iso _TestPipelineShutdownInFlight is UnitTest
 
     let listener =
       _PipelineShutdownInFlightTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -915,15 +915,15 @@ actor \nodoc\ _PipelineShutdownInFlightTestClient is
     end
 
 actor \nodoc\ _PipelineShutdownInFlightTestListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -931,10 +931,10 @@ actor \nodoc\ _PipelineShutdownInFlightTestListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineShutdownInFlightTestServer =>
@@ -947,7 +947,7 @@ actor \nodoc\ _PipelineShutdownInFlightTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -961,30 +961,30 @@ actor \nodoc\ _PipelineShutdownInFlightTestListener
     _h.complete(false)
 
 actor \nodoc\ _PipelineShutdownInFlightTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates + sends ReadyForQuery so the pipeline enters
   _PipelineInFlight, then responds to only the first Sync (so close() fires
   while the pipeline is partially complete).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   var _sync_sent: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1045,7 +1045,7 @@ class \nodoc\ iso _TestPipelineRowModifying is UnitTest
 
     let listener =
       _PipelineRowModifyingTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -1120,15 +1120,15 @@ actor \nodoc\ _PipelineRowModifyingTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _PipelineRowModifyingTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PipelineRowModifyingTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1136,10 +1136,10 @@ actor \nodoc\ _PipelineRowModifyingTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineRowModifyingTestServer =>
@@ -1152,7 +1152,7 @@ actor \nodoc\ _PipelineRowModifyingTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1166,28 +1166,28 @@ actor \nodoc\ _PipelineRowModifyingTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PipelineRowModifyingTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then responds to 2 pipelined INSERT queries
   with CommandComplete("INSERT 0 1") and ReadyForQuery (no RowDescription).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1231,7 +1231,7 @@ class \nodoc\ iso _TestPipelineMixedQueryTypes is UnitTest
 
     let listener =
       _PipelineMixedQueryTypesTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -1301,15 +1301,15 @@ actor \nodoc\ _PipelineMixedQueryTypesTestClient is
     _h.complete(success)
 
 actor \nodoc\ _PipelineMixedQueryTypesTestListener
-  is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1317,10 +1317,10 @@ actor \nodoc\ _PipelineMixedQueryTypesTestListener
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineSuccessTestServer =>
@@ -1332,7 +1332,7 @@ actor \nodoc\ _PipelineMixedQueryTypesTestListener
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1359,7 +1359,7 @@ class \nodoc\ iso _TestPipelineAllFail is UnitTest
 
     let listener =
       _PipelineAllFailTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -1428,15 +1428,15 @@ actor \nodoc\ _PipelineAllFailTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _PipelineAllFailTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PipelineAllFailTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1444,10 +1444,10 @@ actor \nodoc\ _PipelineAllFailTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PipelineAllFailTestServer =>
@@ -1459,7 +1459,7 @@ actor \nodoc\ _PipelineAllFailTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1473,28 +1473,28 @@ actor \nodoc\ _PipelineAllFailTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PipelineAllFailTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, then responds to all pipelined Syncs with
   ErrorResponse + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -1540,7 +1540,7 @@ class \nodoc\ iso _TestPipelineIntegration is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -1670,7 +1670,7 @@ class \nodoc\ iso _TestPipelineIntegrationWithFailure is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_protocol_violation.pony
+++ b/postgres/_test_protocol_violation.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 // Tests for server-driven protocol violations that are detected by the
@@ -37,7 +37,7 @@ class \nodoc\ iso _TestProtocolViolationParseInSCRAM is UnitTest
 
     let listener =
       _PVParseSCRAMListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -67,15 +67,15 @@ actor \nodoc\ _PVParseSCRAMNotify is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _PVParseSCRAMListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVParseSCRAMListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -83,10 +83,10 @@ actor \nodoc\ _PVParseSCRAMListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseSCRAMServer =>
@@ -98,7 +98,7 @@ actor \nodoc\ _PVParseSCRAMListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo(
@@ -111,26 +111,26 @@ actor \nodoc\ _PVParseSCRAMListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PVParseSCRAMServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Starts a SASL SCRAM-SHA-256 exchange, then sends unparseable bytes
   after the client's initial response to force a parse failure while
   the session is in `_SessionSCRAMAuthenticating`.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _phase: USize = 0
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     if _phase == 0 then
       match _reader.read_startup_message()
@@ -148,7 +148,7 @@ actor \nodoc\ _PVParseSCRAMServer
         _tcp_connection.send(_IncomingJunkTestMessage.bytes())
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationParseInFlight is UnitTest
   """
@@ -165,7 +165,7 @@ class \nodoc\ iso _TestProtocolViolationParseInFlight is UnitTest
 
     let listener =
       _PVParseInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -214,15 +214,15 @@ actor \nodoc\ _PVParseInFlightClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _PVParseInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVParseInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -230,10 +230,10 @@ actor \nodoc\ _PVParseInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -245,7 +245,7 @@ actor \nodoc\ _PVParseInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -259,25 +259,25 @@ actor \nodoc\ _PVParseInFlightListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PVParseInFlightServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Authenticates the client, waits for a SimpleQuery, then replies with
   unparseable bytes to force a parse failure while a query is in flight.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _authed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -292,7 +292,7 @@ actor \nodoc\ _PVParseInFlightServer
         _tcp_connection.send(_IncomingJunkTestMessage.bytes())
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationParseIdle is UnitTest
   """
@@ -308,7 +308,7 @@ class \nodoc\ iso _TestProtocolViolationParseIdle is UnitTest
 
     let listener =
       _PVParseIdleListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -338,15 +338,15 @@ actor \nodoc\ _PVParseIdleClient is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _PVParseIdleListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVParseIdleListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -354,10 +354,10 @@ actor \nodoc\ _PVParseIdleListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseIdleServer =>
@@ -369,7 +369,7 @@ actor \nodoc\ _PVParseIdleListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -383,24 +383,24 @@ actor \nodoc\ _PVParseIdleListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PVParseIdleServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Authenticates the client, signals ReadyForQuery, then pushes junk
   while the session is idle (no query in flight).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -408,7 +408,7 @@ actor \nodoc\ _PVParseIdleServer
       _tcp_connection.send(_IncomingReadyForQueryTestMessage('I').bytes())
       _tcp_connection.send(_IncomingJunkTestMessage.bytes())
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStatePreAuth is UnitTest
   """
@@ -426,19 +426,19 @@ class \nodoc\ iso _TestProtocolViolationWrongStatePreAuth is UnitTest
 
     let listener =
       _PVWrongStatePreAuthListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _PVWrongStatePreAuthListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVWrongStatePreAuthListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -446,10 +446,10 @@ actor \nodoc\ _PVWrongStatePreAuthListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVWrongStatePreAuthServer =>
@@ -461,7 +461,7 @@ actor \nodoc\ _PVWrongStatePreAuthListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo(
@@ -474,27 +474,27 @@ actor \nodoc\ _PVWrongStatePreAuthListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PVWrongStatePreAuthServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Replies to the StartupMessage with a `DataRow`, which is invalid
   pre-auth.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _sent: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
-    if _sent then return lori.KeepReading end
+    if _sent then return net.KeepReading end
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
       _sent = true
@@ -502,7 +502,7 @@ actor \nodoc\ _PVWrongStatePreAuthServer
         recover val [as (String | None): "1"] end
       _tcp_connection.send(_IncomingDataRowTestMessage(cols).bytes())
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStateSCRAM is UnitTest
   """
@@ -521,19 +521,19 @@ class \nodoc\ iso _TestProtocolViolationWrongStateSCRAM is UnitTest
 
     let listener =
       _PVWrongStateSCRAMListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _PVWrongStateSCRAMListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVWrongStateSCRAMListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -541,10 +541,10 @@ actor \nodoc\ _PVWrongStateSCRAMListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVWrongStateSCRAMServer =>
@@ -556,7 +556,7 @@ actor \nodoc\ _PVWrongStateSCRAMListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo(
@@ -569,25 +569,25 @@ actor \nodoc\ _PVWrongStateSCRAMListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PVWrongStateSCRAMServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Begins SCRAM-SHA-256, then sends `AuthenticationCleartextPassword`
   mid-exchange.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _phase: USize = 0
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     if _phase == 0 then
       match _reader.read_startup_message()
@@ -606,7 +606,7 @@ actor \nodoc\ _PVWrongStateSCRAMServer
           _IncomingAuthenticationCleartextPasswordTestMessage.bytes())
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStateIdle is UnitTest
   """
@@ -623,19 +623,19 @@ class \nodoc\ iso _TestProtocolViolationWrongStateIdle is UnitTest
 
     let listener =
       _PVWrongStateIdleListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _PVWrongStateIdleListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVWrongStateIdleListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -643,10 +643,10 @@ actor \nodoc\ _PVWrongStateIdleListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVWrongStateIdleServer =>
@@ -658,7 +658,7 @@ actor \nodoc\ _PVWrongStateIdleListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -672,24 +672,24 @@ actor \nodoc\ _PVWrongStateIdleListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PVWrongStateIdleServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Authenticates the client, signals ReadyForQuery, then pushes a second
   `AuthenticationOk` while the session is idle.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     match _reader.read_startup_message()
     | let _: Array[U8] val =>
@@ -697,7 +697,7 @@ actor \nodoc\ _PVWrongStateIdleServer
       _tcp_connection.send(_IncomingReadyForQueryTestMessage('I').bytes())
       _tcp_connection.send(_IncomingAuthenticationOkTestMessage.bytes())
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationWrongStateInFlight is UnitTest
   """
@@ -715,19 +715,19 @@ class \nodoc\ iso _TestProtocolViolationWrongStateInFlight is UnitTest
 
     let listener =
       _PVWrongStateInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _PVWrongStateInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVWrongStateInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -735,10 +735,10 @@ actor \nodoc\ _PVWrongStateInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVWrongStateInFlightServer =>
@@ -750,7 +750,7 @@ actor \nodoc\ _PVWrongStateInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -764,26 +764,26 @@ actor \nodoc\ _PVWrongStateInFlightListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _PVWrongStateInFlightServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Authenticates the client, waits for a SimpleQuery, then replies with
   `AuthenticationOk` — a wire-legal message that is invalid in
   `_SessionLoggedIn`.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _reader: _MockMessageReader = _MockMessageReader
   var _authed: Bool = false
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     if not _authed then
       match _reader.read_startup_message()
@@ -798,7 +798,7 @@ actor \nodoc\ _PVWrongStateInFlightServer
         _tcp_connection.send(_IncomingAuthenticationOkTestMessage.bytes())
       end
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestProtocolViolationCopyInInFlight is UnitTest
   """
@@ -815,7 +815,7 @@ class \nodoc\ iso _TestProtocolViolationCopyInInFlight is UnitTest
 
     let listener =
       _PVCopyInInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -864,15 +864,15 @@ actor \nodoc\ _PVCopyInInFlightClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _PVCopyInInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVCopyInInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -880,10 +880,10 @@ actor \nodoc\ _PVCopyInInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -895,7 +895,7 @@ actor \nodoc\ _PVCopyInInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -923,7 +923,7 @@ class \nodoc\ iso _TestProtocolViolationCopyOutInFlight is UnitTest
 
     let listener =
       _PVCopyOutInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -972,15 +972,15 @@ actor \nodoc\ _PVCopyOutInFlightClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _PVCopyOutInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVCopyOutInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -988,10 +988,10 @@ actor \nodoc\ _PVCopyOutInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -1003,7 +1003,7 @@ actor \nodoc\ _PVCopyOutInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1031,7 +1031,7 @@ class \nodoc\ iso _TestProtocolViolationPrepareInFlight is UnitTest
 
     let listener =
       _PVPrepareInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1077,15 +1077,15 @@ actor \nodoc\ _PVPrepareInFlightClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _PVPrepareInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVPrepareInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1093,10 +1093,10 @@ actor \nodoc\ _PVPrepareInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -1108,7 +1108,7 @@ actor \nodoc\ _PVPrepareInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1136,7 +1136,7 @@ class \nodoc\ iso _TestProtocolViolationStreamInFlight is UnitTest
 
     let listener =
       _PVStreamInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1194,15 +1194,15 @@ actor \nodoc\ _PVStreamInFlightClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _PVStreamInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVStreamInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1210,10 +1210,10 @@ actor \nodoc\ _PVStreamInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -1225,7 +1225,7 @@ actor \nodoc\ _PVStreamInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1256,7 +1256,7 @@ class \nodoc\ iso _TestProtocolViolationPipelineInFlight is UnitTest
 
     let listener =
       _PVPipelineInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1320,15 +1320,15 @@ actor \nodoc\ _PVPipelineInFlightClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _PVPipelineInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVPipelineInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1336,10 +1336,10 @@ actor \nodoc\ _PVPipelineInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -1351,7 +1351,7 @@ actor \nodoc\ _PVPipelineInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1380,7 +1380,7 @@ class \nodoc\ iso _TestProtocolViolationExtendedQueryInFlight is UnitTest
 
     let listener =
       _PVExtendedQueryInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1427,15 +1427,15 @@ actor \nodoc\ _PVExtendedQueryInFlightClient is
     end
     _h.complete(true)
 
-actor \nodoc\ _PVExtendedQueryInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVExtendedQueryInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1443,10 +1443,10 @@ actor \nodoc\ _PVExtendedQueryInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -1458,7 +1458,7 @@ actor \nodoc\ _PVExtendedQueryInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -1488,7 +1488,7 @@ class \nodoc\ iso _TestProtocolViolationCloseStatementInFlight is UnitTest
 
     let listener =
       _PVCloseStatementInFlightListener(
-        lori.TCPListenAuth(h.env.root), host, port, h)
+        net.TCPListenAuth(h.env.root), host, port, h)
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
@@ -1519,15 +1519,15 @@ actor \nodoc\ _PVCloseStatementInFlightClient is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _PVCloseStatementInFlightListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PVCloseStatementInFlightListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -1535,10 +1535,10 @@ actor \nodoc\ _PVCloseStatementInFlightListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _PVParseInFlightServer =>
@@ -1550,7 +1550,7 @@ actor \nodoc\ _PVCloseStatementInFlightListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),

--- a/postgres/_test_query.pony
+++ b/postgres/_test_query.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestQueryResults is UnitTest
@@ -13,7 +13,7 @@ class \nodoc\ iso _TestQueryResults is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -103,7 +103,7 @@ class \nodoc\ iso _TestQueryAfterAuthenticationFailure is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username,
           info.password + " " + info.password,
@@ -166,7 +166,7 @@ class \nodoc\ iso _TestQueryAfterConnectionFailure is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           host,
           info.port.reverse()),
         DatabaseConnectInfo(
@@ -224,7 +224,7 @@ class \nodoc\ iso _TestQueryAfterSessionHasBeenClosed is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         _QueryAfterSessionHasBeenClosedNotify(h))
@@ -282,7 +282,7 @@ class \nodoc\ iso _TestQueryOfNonExistentTable is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -417,7 +417,7 @@ actor \nodoc\ _AllSuccessQueryRunningClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -482,7 +482,7 @@ class \nodoc\ iso _TestEmptyQuery is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -543,7 +543,7 @@ class \nodoc\ iso _TestZeroRowSelect is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -630,7 +630,7 @@ actor \nodoc\ _MultiStatementMixedClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -737,7 +737,7 @@ class \nodoc\ iso _TestPreparedQueryResults is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -833,7 +833,7 @@ class \nodoc\ iso _TestPreparedQueryNullParam is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -924,7 +924,7 @@ class \nodoc\ iso _TestPreparedQueryNonExistentTable is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -1001,7 +1001,7 @@ actor \nodoc\ _PreparedQueryInsertAndDeleteClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1126,7 +1126,7 @@ actor \nodoc\ _PreparedQueryMixedClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1251,7 +1251,7 @@ actor \nodoc\ _PrepareStatementClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1312,7 +1312,7 @@ actor \nodoc\ _PrepareAndExecuteClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1402,7 +1402,7 @@ actor \nodoc\ _PrepareAndExecuteMultipleClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1515,7 +1515,7 @@ actor \nodoc\ _PrepareAndCloseClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1592,7 +1592,7 @@ actor \nodoc\ _PrepareFailsClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1659,7 +1659,7 @@ actor \nodoc\ _PrepareAfterCloseClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1760,7 +1760,7 @@ actor \nodoc\ _CloseNonexistentClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1818,7 +1818,7 @@ actor \nodoc\ _PrepareDuplicateNameClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -1892,7 +1892,7 @@ actor \nodoc\ _MixedAllThreeClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -2015,7 +2015,7 @@ actor \nodoc\ _CopyInInsertClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -2143,7 +2143,7 @@ actor \nodoc\ _CopyInAbortRollbackClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         this)
@@ -2248,7 +2248,7 @@ class \nodoc\ iso _TestQueryByteaResults is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)
@@ -2329,7 +2329,7 @@ class \nodoc\ iso _TestPreparedQueryTypedResults is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root), info.host, info.port),
+          net.TCPConnectAuth(h.env.root), info.host, info.port),
         DatabaseConnectInfo(
           info.username, info.password, info.database),
         client)

--- a/postgres/_test_session.pony
+++ b/postgres/_test_session.pony
@@ -1,5 +1,5 @@
 use "collections"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestHandlingJunkMessages is UnitTest
@@ -17,7 +17,7 @@ class \nodoc\ iso _TestHandlingJunkMessages is UnitTest
 
     let listener =
       _JunkSendingTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -52,18 +52,18 @@ actor \nodoc\ _HandlingJunkTestNotify is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _JunkSendingTestListener is lori.TCPListenerActor
+actor \nodoc\ _JunkSendingTestListener is net.TCPListenerActor
   """
   Listens for incoming connections and starts a server that will always reply
   with junk.
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -71,10 +71,10 @@ actor \nodoc\ _JunkSendingTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _JunkSendingTestServer =>
@@ -87,7 +87,7 @@ actor \nodoc\ _JunkSendingTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port),
         DatabaseConnectInfo(
@@ -100,30 +100,30 @@ actor \nodoc\ _JunkSendingTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _JunkSendingTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Sends junk "postgres messages" in reponse to any incoming activity. This actor
   is used to test that our client handles getting junk correctly.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
   fun ref _on_started() =>
     let junk = _IncomingJunkTestMessage.bytes()
     _tcp_connection.send(junk)
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     let junk = _IncomingJunkTestMessage.bytes()
     _tcp_connection.send(junk)
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestUnansweredQueriesFailOnShutdown is UnitTest
   """
@@ -144,7 +144,7 @@ class \nodoc\ iso _TestUnansweredQueriesFailOnShutdown is UnitTest
 
     let listener =
       _DoesntAnswerTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -200,17 +200,17 @@ actor \nodoc\ _DoesntAnswerClient is (SessionStatusNotify & ResultReceiver)
     _in_flight_queries.set(q)
     session.execute(q, this)
 
-actor \nodoc\ _DoesntAnswerTestListener is lori.TCPListenerActor
+actor \nodoc\ _DoesntAnswerTestListener is net.TCPListenerActor
   """
   Listens for incoming connections and starts a server that will never reply
   """
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -218,10 +218,10 @@ actor \nodoc\ _DoesntAnswerTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
@@ -234,7 +234,7 @@ actor \nodoc\ _DoesntAnswerTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -248,7 +248,7 @@ actor \nodoc\ _DoesntAnswerTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _DoesntAnswerTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Simulates a misbehaving server that authenticates clients but never becomes
   ready for queries. It sends AuthenticationOk but intentionally omits the
@@ -258,18 +258,18 @@ actor \nodoc\ _DoesntAnswerTestServer
   drains the queue and delivers SessionClosed failures to each receiver.
   """
   var _authed: Bool = false
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     """
     Sends AuthenticationOk on first contact without requiring a password.
     Intentionally does NOT send ReadyForQuery afterward — this is the
@@ -280,7 +280,7 @@ actor \nodoc\ _DoesntAnswerTestServer
       let auth_ok = _IncomingAuthenticationOkTestMessage.bytes()
       _tcp_connection.send(auth_ok)
     end
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestZeroRowSelectReturnsResultSet is UnitTest
   """
@@ -297,7 +297,7 @@ class \nodoc\ iso _TestZeroRowSelectReturnsResultSet is UnitTest
 
     let listener =
       _ZeroRowSelectTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -365,14 +365,14 @@ actor \nodoc\ _ZeroRowSelectTestClient is (SessionStatusNotify & ResultReceiver)
     end
     _h.complete(success)
 
-actor \nodoc\ _ZeroRowSelectTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _ZeroRowSelectTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -380,10 +380,10 @@ actor \nodoc\ _ZeroRowSelectTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ZeroRowSelectTestServer =>
@@ -395,7 +395,7 @@ actor \nodoc\ _ZeroRowSelectTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -409,29 +409,29 @@ actor \nodoc\ _ZeroRowSelectTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _ZeroRowSelectTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates and then responds to a query with
   RowDescription + CommandComplete("SELECT 0") — simulating a SELECT that
   returns zero rows.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -477,7 +477,7 @@ class \nodoc\ iso _TestPrepareShutdownDrainsPrepareQueue is UnitTest
 
     let listener =
       _PrepareShutdownTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -525,14 +525,14 @@ actor \nodoc\ _PrepareShutdownTestClient is
       _h.complete(false)
     end
 
-actor \nodoc\ _PrepareShutdownTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _PrepareShutdownTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -540,10 +540,10 @@ actor \nodoc\ _PrepareShutdownTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
@@ -555,7 +555,7 @@ actor \nodoc\ _PrepareShutdownTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -584,7 +584,7 @@ class \nodoc\ iso _TestTerminateSentOnClose is UnitTest
 
     let listener =
       _TerminateSentTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -607,14 +607,14 @@ actor \nodoc\ _TerminateSentTestNotify is SessionStatusNotify
     _h.fail("Unable to establish connection.")
     _h.complete(false)
 
-actor \nodoc\ _TerminateSentTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _TerminateSentTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -622,10 +622,10 @@ actor \nodoc\ _TerminateSentTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TerminateSentTestServer =>
@@ -637,7 +637,7 @@ actor \nodoc\ _TerminateSentTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -651,30 +651,30 @@ actor \nodoc\ _TerminateSentTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _TerminateSentTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates clients and verifies that a Terminate
   message ('X') is received before the connection closes.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _h: TestHelper
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32, h: TestHelper) =>
+  new create(auth: net.TCPServerAuth, fd: U32, h: TestHelper) =>
     _h = h
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -713,7 +713,7 @@ class \nodoc\ iso _TestByteaResultDecoding is UnitTest
 
     let listener =
       _ByteaTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -737,7 +737,7 @@ class \nodoc\ iso _TestEmptyByteaResultDecoding is UnitTest
 
     let listener =
       _ByteaTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -801,16 +801,16 @@ actor \nodoc\ _ByteaTestClient is (SessionStatusNotify & ResultReceiver)
     end
     _h.complete(success)
 
-actor \nodoc\ _ByteaTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _ByteaTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _hex_data: String
   let _expected: Array[U8] val
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
@@ -822,10 +822,10 @@ actor \nodoc\ _ByteaTestListener is lori.TCPListenerActor
     _h = h
     _hex_data = hex_data
     _expected = expected
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _ByteaTestServer =>
@@ -837,7 +837,7 @@ actor \nodoc\ _ByteaTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -851,31 +851,31 @@ actor \nodoc\ _ByteaTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _ByteaTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates and responds to a query with
   RowDescription (one bytea column) + DataRow (hex-encoded value) +
   CommandComplete("SELECT 1") + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
   let _hex_data: String
 
-  new create(auth: lori.TCPServerAuth, fd: U32, hex_data: String) =>
+  new create(auth: net.TCPServerAuth, fd: U32, hex_data: String) =>
     _hex_data = hex_data
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then

--- a/postgres/_test_ssl.pony
+++ b/postgres/_test_ssl.pony
@@ -1,5 +1,5 @@
 use "files"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 // SSL negotiation unit tests
@@ -18,14 +18,14 @@ class \nodoc\ iso _TestSSLNegotiationRefused is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let listener =
       _SSLRefusedTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -64,28 +64,28 @@ actor \nodoc\ _SSLRefusedTestNotify is SessionStatusNotify
       _h.complete(true)
     end
 
-actor \nodoc\ _SSLRefusedTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLRefusedTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: lori.SSLContext val
+  let _sslctx: net.SSLContext val
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: lori.SSLContext val)
+    sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _sslctx = sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLRefusedTestServer =>
@@ -97,7 +97,7 @@ actor \nodoc\ _SSLRefusedTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLRequired(_sslctx)),
@@ -111,25 +111,25 @@ actor \nodoc\ _SSLRefusedTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SSLRefusedTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that responds 'N' to an SSLRequest, refusing SSL.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     let response: Array[U8] val = ['N']
     _tcp_connection.send(response)
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestSSLNegotiationJunkResponse is UnitTest
   """
@@ -147,14 +147,14 @@ class \nodoc\ iso _TestSSLNegotiationJunkResponse is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let listener =
       _SSLJunkTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -194,28 +194,28 @@ actor \nodoc\ _SSLJunkTestNotify is SessionStatusNotify
     end
     _h.complete(true)
 
-actor \nodoc\ _SSLJunkTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLJunkTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: lori.SSLContext val
+  let _sslctx: net.SSLContext val
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: lori.SSLContext val)
+    sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _sslctx = sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLJunkTestServer =>
@@ -227,7 +227,7 @@ actor \nodoc\ _SSLJunkTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLRequired(_sslctx)),
@@ -241,25 +241,25 @@ actor \nodoc\ _SSLJunkTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SSLJunkTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that responds with a junk byte to an SSLRequest.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     let response: Array[U8] val = ['X']
     _tcp_connection.send(response)
-    lori.KeepReading
+    net.KeepReading
 
 class \nodoc\ iso _TestSSLNegotiationSuccess is UnitTest
   """
@@ -281,14 +281,14 @@ class \nodoc\ iso _TestSSLNegotiationSuccess is UnitTest
 
     let client_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -296,7 +296,7 @@ class \nodoc\ iso _TestSSLNegotiationSuccess is UnitTest
 
     let listener =
       _SSLSuccessTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -334,31 +334,31 @@ actor \nodoc\ _SSLSuccessTestNotify is SessionStatusNotify
       _h.complete(false)
     end
 
-actor \nodoc\ _SSLSuccessTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLSuccessTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: lori.SSLContext val
-  let _server_sslctx: lori.SSLContext val
+  let _client_sslctx: net.SSLContext val
+  let _server_sslctx: net.SSLContext val
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: lori.SSLContext val,
-    server_sslctx: lori.SSLContext val)
+    client_sslctx: net.SSLContext val,
+    server_sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _client_sslctx = client_sslctx
     _server_sslctx = server_sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLSuccessTestServer =>
@@ -370,7 +370,7 @@ actor \nodoc\ _SSLSuccessTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLRequired(_client_sslctx)
@@ -385,31 +385,31 @@ actor \nodoc\ _SSLSuccessTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SSLSuccessTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that responds 'S' to an SSLRequest, upgrades to TLS on its
   side, then sends AuthenticationOk + ReadyForQuery over the encrypted
   connection once it receives the StartupMessage.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
-  let _sslctx: lori.SSLContext val
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
+  let _sslctx: net.SSLContext val
   var _ssl_started: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, sslctx: lori.SSLContext val, fd: U32) =>
+  new create(auth: net.TCPServerAuth, sslctx: net.SSLContext val, fd: U32) =>
     _sslctx = sslctx
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _ssl_started then
@@ -420,7 +420,7 @@ actor \nodoc\ _SSLSuccessTestServer
         _tcp_connection.send(response)
         match \exhaustive\ _tcp_connection.start_tls(_sslctx)
         | None => _ssl_started = true
-        | let _: lori.StartTLSError =>
+        | let _: net.StartTLSError =>
           _tcp_connection.close()
         end
       end
@@ -449,7 +449,7 @@ class \nodoc\ iso _TestSSLConnect is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -457,7 +457,7 @@ class \nodoc\ iso _TestSSLConnect is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port,
           SSLRequired(sslctx)),
@@ -481,7 +481,7 @@ class \nodoc\ iso _TestSSLAuthenticate is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -489,7 +489,7 @@ class \nodoc\ iso _TestSSLAuthenticate is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port,
           SSLRequired(sslctx)),
@@ -513,7 +513,7 @@ class \nodoc\ iso _TestSSLQueryResults is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -523,7 +523,7 @@ class \nodoc\ iso _TestSSLQueryResults is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port,
           SSLRequired(sslctx)),
@@ -549,7 +549,7 @@ class \nodoc\ iso _TestSSLRefused is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -557,7 +557,7 @@ class \nodoc\ iso _TestSSLRefused is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port,
           SSLRequired(sslctx)),
@@ -584,14 +584,14 @@ class \nodoc\ iso _TestSSLPreferredFallback is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let listener =
       _SSLPreferredFallbackTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -633,28 +633,28 @@ actor \nodoc\ _SSLPreferredFallbackTestNotify is SessionStatusNotify
       _h.complete(false)
     end
 
-actor \nodoc\ _SSLPreferredFallbackTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLPreferredFallbackTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _sslctx: lori.SSLContext val
+  let _sslctx: net.SSLContext val
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    sslctx: lori.SSLContext val)
+    sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _sslctx = sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLPreferredFallbackTestServer =>
@@ -666,7 +666,7 @@ actor \nodoc\ _SSLPreferredFallbackTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLPreferred(_sslctx)
@@ -681,28 +681,28 @@ actor \nodoc\ _SSLPreferredFallbackTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SSLPreferredFallbackTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that responds 'N' to an SSLRequest (refusing SSL), then reads
   the plaintext StartupMessage and sends AuthOk + ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _ssl_refused: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _ssl_refused then
@@ -745,14 +745,14 @@ class \nodoc\ iso _TestSSLPreferredSuccess is UnitTest
 
     let client_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -760,7 +760,7 @@ class \nodoc\ iso _TestSSLPreferredSuccess is UnitTest
 
     let listener =
       _SSLPreferredSuccessTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -797,31 +797,31 @@ actor \nodoc\ _SSLPreferredSuccessTestNotify is SessionStatusNotify
       _h.complete(false)
     end
 
-actor \nodoc\ _SSLPreferredSuccessTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLPreferredSuccessTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: lori.SSLContext val
-  let _server_sslctx: lori.SSLContext val
+  let _client_sslctx: net.SSLContext val
+  let _server_sslctx: net.SSLContext val
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: lori.SSLContext val,
-    server_sslctx: lori.SSLContext val)
+    client_sslctx: net.SSLContext val,
+    server_sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _client_sslctx = client_sslctx
     _server_sslctx = server_sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLSuccessTestServer =>
@@ -833,7 +833,7 @@ actor \nodoc\ _SSLPreferredSuccessTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLPreferred(_client_sslctx)
@@ -866,10 +866,10 @@ class \nodoc\ iso _TestSSLPreferredTLSFailure is UnitTest
     // handshake to fail.
     let client_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
-          .> set_min_proto_version(lori.TLS1u3Version())?
+          .> set_min_proto_version(net.TLS1u3Version())?
       end
 
     let cert_path =
@@ -879,16 +879,16 @@ class \nodoc\ iso _TestSSLPreferredTLSFailure is UnitTest
 
     let server_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
-          .> set_max_proto_version(lori.TLS1u2Version())?
+          .> set_max_proto_version(net.TLS1u2Version())?
       end
 
     let listener =
       _SSLPreferredTLSFailureTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -917,31 +917,31 @@ actor \nodoc\ _SSLPreferredTLSFailureTestNotify is SessionStatusNotify
     _h.fail("Should not have authenticated after TLS failure")
     _h.complete(false)
 
-actor \nodoc\ _SSLPreferredTLSFailureTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLPreferredTLSFailureTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: lori.SSLContext val
-  let _server_sslctx: lori.SSLContext val
+  let _client_sslctx: net.SSLContext val
+  let _server_sslctx: net.SSLContext val
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: lori.SSLContext val,
-    server_sslctx: lori.SSLContext val)
+    client_sslctx: net.SSLContext val,
+    server_sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _client_sslctx = client_sslctx
     _server_sslctx = server_sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLSuccessTestServer =>
@@ -955,7 +955,7 @@ actor \nodoc\ _SSLPreferredTLSFailureTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLPreferred(_client_sslctx)),
@@ -989,14 +989,14 @@ class \nodoc\ iso _TestSSLPreferredCancelFallback is UnitTest
 
     let client_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
 
     let server_sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_cert(cert_path, key_path)?
           .> set_client_verify(false)
           .> set_server_verify(false)
@@ -1004,7 +1004,7 @@ class \nodoc\ iso _TestSSLPreferredCancelFallback is UnitTest
 
     let listener =
       _SSLPreferredCancelTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h,
@@ -1014,32 +1014,32 @@ class \nodoc\ iso _TestSSLPreferredCancelFallback is UnitTest
     h.dispose_when_done(listener)
     h.long_test(5_000_000_000)
 
-actor \nodoc\ _SSLPreferredCancelTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _SSLPreferredCancelTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
-  let _client_sslctx: lori.SSLContext val
-  let _server_sslctx: lori.SSLContext val
+  let _client_sslctx: net.SSLContext val
+  let _server_sslctx: net.SSLContext val
   var _connection_count: USize = 0
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper,
-    client_sslctx: lori.SSLContext val,
-    server_sslctx: lori.SSLContext val)
+    client_sslctx: net.SSLContext val,
+    server_sslctx: net.SSLContext val)
   =>
     _host = host
     _port = port
     _h = h
     _client_sslctx = client_sslctx
     _server_sslctx = server_sslctx
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _SSLPreferredCancelTestServer =>
@@ -1058,7 +1058,7 @@ actor \nodoc\ _SSLPreferredCancelTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port,
           SSLPreferred(_client_sslctx)
@@ -1073,14 +1073,14 @@ actor \nodoc\ _SSLPreferredCancelTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _SSLPreferredCancelTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that handles two connections: the first (main session) accepts
   SSL and authenticates; the second (cancel sender) refuses SSL ('N') so the
   cancel falls back to plaintext, then verifies the CancelRequest.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
-  let _sslctx: lori.SSLContext val
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
+  let _sslctx: net.SSLContext val
   let _h: TestHelper
   let _is_cancel_connection: Bool
   var _ssl_started: Bool = false
@@ -1089,8 +1089,8 @@ actor \nodoc\ _SSLPreferredCancelTestServer
   let _reader: _MockMessageReader = _MockMessageReader
 
   new create(
-    auth: lori.TCPServerAuth,
-    sslctx: lori.SSLContext val,
+    auth: net.TCPServerAuth,
+    sslctx: net.SSLContext val,
     fd: U32,
     h: TestHelper,
     is_cancel: Bool)
@@ -1098,18 +1098,18 @@ actor \nodoc\ _SSLPreferredCancelTestServer
     _sslctx = sslctx
     _h = h
     _is_cancel_connection = is_cancel
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _is_cancel_connection then
@@ -1180,7 +1180,7 @@ actor \nodoc\ _SSLPreferredCancelTestServer
           _tcp_connection.send(response)
           match \exhaustive\ _tcp_connection.start_tls(_sslctx)
           | None => _ssl_started = true
-          | let _: lori.StartTLSError =>
+          | let _: net.StartTLSError =>
             _tcp_connection.close()
           end
         end
@@ -1218,7 +1218,7 @@ class \nodoc\ iso _TestSSLPreferredWithSSLServer is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -1226,7 +1226,7 @@ class \nodoc\ iso _TestSSLPreferredWithSSLServer is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.ssl_host,
           info.ssl_port,
           SSLPreferred(sslctx)),
@@ -1251,7 +1251,7 @@ class \nodoc\ iso _TestSSLPreferredWithPlainServer is UnitTest
 
     let sslctx =
       recover val
-        lori.SSLContext
+        net.SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
@@ -1259,7 +1259,7 @@ class \nodoc\ iso _TestSSLPreferredWithPlainServer is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port,
           SSLPreferred(sslctx)),

--- a/postgres/_test_statement_timeout.pony
+++ b/postgres/_test_statement_timeout.pony
@@ -1,5 +1,5 @@
 use "constrained_types"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestStatementTimeoutFires is UnitTest
@@ -18,7 +18,7 @@ class \nodoc\ iso _TestStatementTimeoutFires is UnitTest
 
     let listener =
       _TimeoutTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -41,8 +41,8 @@ actor \nodoc\ _TimeoutTestClient is (SessionStatusNotify & ResultReceiver)
   be pg_session_authenticated(session: Session) =>
     // Execute a query with a 100ms timeout. The mock server will hold
     // (not respond), so the timer will fire and send a CancelRequest.
-    match \exhaustive\ lori.MakeTimerDuration(100)
-    | let d: lori.TimerDuration =>
+    match \exhaustive\ net.MakeTimerDuration(100)
+    | let d: net.TimerDuration =>
       session.execute(
         SimpleQuery("SELECT pg_sleep(100)"),
         this
@@ -62,15 +62,15 @@ actor \nodoc\ _TimeoutTestClient is (SessionStatusNotify & ResultReceiver)
   =>
     None
 
-actor \nodoc\ _TimeoutTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _TimeoutTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   var _connection_count: USize = 0
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -78,10 +78,10 @@ actor \nodoc\ _TimeoutTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TimeoutTestServer =>
@@ -96,7 +96,7 @@ actor \nodoc\ _TimeoutTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -110,38 +110,38 @@ actor \nodoc\ _TimeoutTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _TimeoutTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that handles two connections: the first is the main session
   (authenticates, receives query, and holds without responding), the second
   is the cancel sender (verifies CancelRequest format and content).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   let _is_cancel_connection: Bool
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
   new create(
-    auth: lori.TCPServerAuth,
+    auth: net.TCPServerAuth,
     fd: U32,
     h: TestHelper,
     is_cancel: Bool)
   =>
     _h = h
     _is_cancel_connection = is_cancel
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _is_cancel_connection then
@@ -231,7 +231,7 @@ class \nodoc\ iso _TestStatementTimeoutRearmOnTimerFailure is UnitTest
 
     let listener =
       _TimeoutRearmTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -257,8 +257,8 @@ actor \nodoc\ _TimeoutRearmTestClient is (SessionStatusNotify & ResultReceiver)
     // processes `execute` first (arms the original timer), then the
     // simulation (cancels the original token and rearms with 200ms). The
     // rearmed timer fires and sends a CancelRequest on a second connection.
-    match \exhaustive\ lori.MakeTimerDuration(200)
-    | let d: lori.TimerDuration =>
+    match \exhaustive\ net.MakeTimerDuration(200)
+    | let d: net.TimerDuration =>
       session.execute(
         SimpleQuery("SELECT pg_sleep(100)"),
         this
@@ -279,15 +279,15 @@ actor \nodoc\ _TimeoutRearmTestClient is (SessionStatusNotify & ResultReceiver)
   =>
     None
 
-actor \nodoc\ _TimeoutRearmTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _TimeoutRearmTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   var _connection_count: USize = 0
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -295,10 +295,10 @@ actor \nodoc\ _TimeoutRearmTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TimeoutTestServer =>
@@ -313,7 +313,7 @@ actor \nodoc\ _TimeoutRearmTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -341,7 +341,7 @@ class \nodoc\ iso _TestStatementTimeoutCancelledOnCompletion is UnitTest
 
     let listener =
       _TimeoutCancelledTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -365,8 +365,8 @@ actor \nodoc\ _TimeoutCancelledTestClient
   be pg_session_authenticated(session: Session) =>
     // Execute with a long timeout (5s). The mock server responds immediately,
     // so the timer should be cancelled and pg_query_result should fire.
-    match \exhaustive\ lori.MakeTimerDuration(5000)
-    | let d: lori.TimerDuration =>
+    match \exhaustive\ net.MakeTimerDuration(5000)
+    | let d: net.TimerDuration =>
       session.execute(
         SimpleQuery("SELECT 1"),
         this
@@ -387,14 +387,14 @@ actor \nodoc\ _TimeoutCancelledTestClient
     _h.fail("Query should have completed successfully.")
     _h.complete(false)
 
-actor \nodoc\ _TimeoutCancelledTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _TimeoutCancelledTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -402,10 +402,10 @@ actor \nodoc\ _TimeoutCancelledTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TimeoutCancelledTestServer =>
@@ -417,7 +417,7 @@ actor \nodoc\ _TimeoutCancelledTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -431,30 +431,30 @@ actor \nodoc\ _TimeoutCancelledTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _TimeoutCancelledTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates the session and immediately responds to the
   query with a successful result, before the statement timeout can fire.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _h: TestHelper
   var _authed: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32, h: TestHelper) =>
+  new create(auth: net.TCPServerAuth, fd: U32, h: TestHelper) =>
     _h = h
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -508,7 +508,7 @@ class \nodoc\ iso _TestStatementTimeoutPgSleep is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -529,8 +529,8 @@ actor \nodoc\ _TimeoutPgSleepClient is
     _query = SimpleQuery("SELECT pg_sleep(30)")
 
   be pg_session_authenticated(session: Session) =>
-    match \exhaustive\ lori.MakeTimerDuration(1000)
-    | let d: lori.TimerDuration =>
+    match \exhaustive\ net.MakeTimerDuration(1000)
+    | let d: net.TimerDuration =>
       session.execute(_query, this where statement_timeout = d)
     | let _: ValidationFailure =>
       _h.fail("Failed to create TimerDuration.")

--- a/postgres/_test_streaming.pony
+++ b/postgres/_test_streaming.pony
@@ -1,5 +1,5 @@
 use "collections"
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestStreamingSuccess is UnitTest
@@ -17,7 +17,7 @@ class \nodoc\ iso _TestStreamingSuccess is UnitTest
 
     let listener =
       _StreamingSuccessTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -81,14 +81,14 @@ actor \nodoc\ _StreamingSuccessTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _StreamingSuccessTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _StreamingSuccessTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -96,10 +96,10 @@ actor \nodoc\ _StreamingSuccessTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingSuccessTestServer =>
@@ -111,7 +111,7 @@ actor \nodoc\ _StreamingSuccessTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -125,7 +125,7 @@ actor \nodoc\ _StreamingSuccessTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _StreamingSuccessTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds to an extended query pipeline
   with RowDescription, then simulates streaming: first Execute returns
@@ -133,24 +133,24 @@ actor \nodoc\ _StreamingSuccessTestServer
   PortalSuspended, third Execute returns 1 DataRow + CommandComplete +
   ReadyForQuery (after Sync).
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   var _execute_count: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -259,7 +259,7 @@ class \nodoc\ iso _TestStreamingEmpty is UnitTest
 
     let listener =
       _StreamingEmptyTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -315,14 +315,14 @@ actor \nodoc\ _StreamingEmptyTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _StreamingEmptyTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _StreamingEmptyTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -330,10 +330,10 @@ actor \nodoc\ _StreamingEmptyTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingEmptyTestServer =>
@@ -345,7 +345,7 @@ actor \nodoc\ _StreamingEmptyTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -359,28 +359,28 @@ actor \nodoc\ _StreamingEmptyTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _StreamingEmptyTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that responds to a streaming query with RowDescription +
   CommandComplete("SELECT 0") — zero rows, no PortalSuspended.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -445,7 +445,7 @@ class \nodoc\ iso _TestStreamingEarlyStop is UnitTest
 
     let listener =
       _StreamingEarlyStopTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -503,14 +503,14 @@ actor \nodoc\ _StreamingEarlyStopTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _StreamingEarlyStopTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _StreamingEarlyStopTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -518,10 +518,10 @@ actor \nodoc\ _StreamingEarlyStopTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingEarlyStopTestServer =>
@@ -533,7 +533,7 @@ actor \nodoc\ _StreamingEarlyStopTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -547,29 +547,29 @@ actor \nodoc\ _StreamingEarlyStopTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _StreamingEarlyStopTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds to first Execute with 2 DataRows +
   PortalSuspended, then responds to Sync (from close_stream) with
   ReadyForQuery.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -646,7 +646,7 @@ class \nodoc\ iso _TestStreamingServerError is UnitTest
 
     let listener =
       _StreamingServerErrorTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -716,14 +716,14 @@ actor \nodoc\ _StreamingServerErrorTestClient is
     end
     _h.complete(success)
 
-actor \nodoc\ _StreamingServerErrorTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _StreamingServerErrorTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -731,10 +731,10 @@ actor \nodoc\ _StreamingServerErrorTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _StreamingServerErrorTestServer =>
@@ -746,7 +746,7 @@ actor \nodoc\ _StreamingServerErrorTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -760,30 +760,30 @@ actor \nodoc\ _StreamingServerErrorTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _StreamingServerErrorTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates, responds to the streaming query pipeline
   with ErrorResponse (before any data), then responds to the follow-up
   simple query normally.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _state: U8 = 0
   var _error_sent: Bool = false
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if _state == 0 then
@@ -871,7 +871,7 @@ class \nodoc\ iso _TestStreamingShutdownDrainsQueue is UnitTest
 
     let listener =
       _StreamingShutdownTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         h)
@@ -932,14 +932,14 @@ actor \nodoc\ _StreamingShutdownTestClient is
       _h.complete(false)
     end
 
-actor \nodoc\ _StreamingShutdownTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _StreamingShutdownTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
 
-  new create(listen_auth: lori.TCPListenAuth,
+  new create(listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     h: TestHelper)
@@ -947,10 +947,10 @@ actor \nodoc\ _StreamingShutdownTestListener is lori.TCPListenerActor
     _host = host
     _port = port
     _h = h
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _DoesntAnswerTestServer =>
@@ -962,7 +962,7 @@ actor \nodoc\ _StreamingShutdownTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -989,7 +989,7 @@ class \nodoc\ iso _TestStreamingQueryResults is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -1102,7 +1102,7 @@ class \nodoc\ iso _TestStreamingAfterSessionClosed is UnitTest
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/_test_transaction_status.pony
+++ b/postgres/_test_transaction_status.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 use "pony_test"
 
 class \nodoc\ iso _TestTransactionStatusOnAuthentication is UnitTest
@@ -15,7 +15,7 @@ class \nodoc\ iso _TestTransactionStatusOnAuthentication is UnitTest
 
     let listener =
       _TxnStatusTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _TxnStatusOnAuthClient(h),
@@ -61,7 +61,7 @@ class \nodoc\ iso _TestTransactionStatusDuringTransaction is UnitTest
 
     let listener =
       _TxnStatusTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _TxnStatusDuringTxnClient(h),
@@ -147,7 +147,7 @@ class \nodoc\ iso _TestTransactionStatusOnFailedTransaction is UnitTest
 
     let listener =
       _TxnStatusTestListener(
-        lori.TCPListenAuth(h.env.root),
+        net.TCPListenAuth(h.env.root),
         host,
         port,
         _TxnStatusFailedClient(h),
@@ -228,16 +228,16 @@ actor \nodoc\ _TxnStatusFailedClient
     _h.complete(false)
 
 // Shared infrastructure for transaction status tests
-actor \nodoc\ _TxnStatusTestListener is lori.TCPListenerActor
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
-  let _server_auth: lori.TCPServerAuth
+actor \nodoc\ _TxnStatusTestListener is net.TCPListenerActor
+  var _tcp_listener: net.TCPListener = net.TCPListener.none()
+  let _server_auth: net.TCPServerAuth
   let _h: TestHelper
   let _host: String
   let _port: String
   let _notify: SessionStatusNotify
 
   new create(
-    listen_auth: lori.TCPListenAuth,
+    listen_auth: net.TCPListenAuth,
     host: String,
     port: String,
     notify: SessionStatusNotify,
@@ -247,10 +247,10 @@ actor \nodoc\ _TxnStatusTestListener is lori.TCPListenerActor
     _port = port
     _h = h
     _notify = notify
-    _server_auth = lori.TCPServerAuth(listen_auth)
-    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+    _server_auth = net.TCPServerAuth(listen_auth)
+    _tcp_listener = net.TCPListener(listen_auth, host, port, this)
 
-  fun ref _listener(): lori.TCPListener =>
+  fun ref _listener(): net.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TxnStatusTestServer =>
@@ -262,7 +262,7 @@ actor \nodoc\ _TxnStatusTestListener is lori.TCPListenerActor
     let session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(_h.env.root),
+          net.TCPConnectAuth(_h.env.root),
           _host,
           _port
           where auth_requirement' = AllowAnyAuth),
@@ -276,29 +276,29 @@ actor \nodoc\ _TxnStatusTestListener is lori.TCPListenerActor
     _h.complete(false)
 
 actor \nodoc\ _TxnStatusTestServer
-  is (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  is (net.TCPConnectionActor & net.ServerLifecycleEventReceiver)
   """
   Mock server that authenticates and responds to queries with
   appropriate transaction status bytes.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   var _authed: Bool = false
   var _txn_state: U8 = 'I'
   let _reader: _MockMessageReader = _MockMessageReader
 
-  new create(auth: lori.TCPServerAuth, fd: U32) =>
-    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+  new create(auth: net.TCPServerAuth, fd: U32) =>
+    _tcp_connection = net.TCPConnection.server(auth, fd, this, this)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
-  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+  fun ref _on_start_failure(reason: net.StartFailureReason) =>
     None
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     _reader.append(consume data)
     _process()
-    lori.KeepReading
+    net.KeepReading
 
   fun ref _process() =>
     if not _authed then
@@ -416,7 +416,7 @@ actor \nodoc\ _TransactionCommitClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(
@@ -529,7 +529,7 @@ actor \nodoc\ _TransactionRollbackClient is
     _session =
       Session(
         ServerConnectInfo(
-          lori.TCPConnectAuth(h.env.root),
+          net.TCPConnectAuth(h.env.root),
           info.host,
           info.port),
         DatabaseConnectInfo(

--- a/postgres/postgres.pony
+++ b/postgres/postgres.pony
@@ -11,12 +11,12 @@ Create a `Session` with server and database connection info plus a
 
 ```pony
 use "postgres"
-use lori = "lori"
+use "net"
 
 actor Main
   new create(env: Env) =>
     let session = Session(
-      ServerConnectInfo(lori.TCPConnectAuth(env.root), "localhost", "5432"),
+      ServerConnectInfo(TCPConnectAuth(env.root), "localhost", "5432"),
       DatabaseConnectInfo("myuser", "mypassword", "mydb"),
       MyNotify(env))
 
@@ -71,7 +71,7 @@ Two SSL modes are available:
 
 ```pony
 let sslctx = recover val
-  lori.SSLContext
+  SSLContext
     .> set_client_verify(true)
     .> set_authority(FilePath(FileAuth(env.root), "/path/to/ca.pem"))?
 end
@@ -79,7 +79,7 @@ end
 // Require SSL — fail if server refuses
 let session = Session(
   ServerConnectInfo(
-    lori.TCPConnectAuth(env.root), "localhost", "5432",
+    TCPConnectAuth(env.root), "localhost", "5432",
     SSLRequired(sslctx)),
   DatabaseConnectInfo("myuser", "mypassword", "mydb"),
   MyNotify(env))
@@ -87,7 +87,7 @@ let session = Session(
 // Prefer SSL — fall back to plaintext if server refuses
 let session2 = Session(
   ServerConnectInfo(
-    lori.TCPConnectAuth(env.root), "localhost", "5432",
+    TCPConnectAuth(env.root), "localhost", "5432",
     SSLPreferred(sslctx)),
   DatabaseConnectInfo("myuser", "mypassword", "mydb"),
   MyNotify(env))
@@ -116,7 +116,7 @@ non-SCRAM server, pass `AllowAnyAuth`:
 ```pony
 let session = Session(
   ServerConnectInfo(
-    lori.TCPConnectAuth(env.root), "localhost", "5432",
+    TCPConnectAuth(env.root), "localhost", "5432",
     SSLDisabled, AllowAnyAuth),
   DatabaseConnectInfo("myuser", "mypassword", "mydb"),
   MyNotify(env))

--- a/postgres/server_connect_info.pony
+++ b/postgres/server_connect_info.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 
 class val ServerConnectInfo
   """
@@ -14,22 +14,22 @@ class val ServerConnectInfo
   timeout fires before a TCP connection is established,
   `pg_session_connection_failed`
   is called with `ConnectionFailedTimeout`. Construct the timeout with
-  `lori.MakeConnectionTimeout(milliseconds)`.
+  `net.MakeConnectionTimeout(milliseconds)`.
   """
-  let auth: lori.TCPConnectAuth
+  let auth: net.TCPConnectAuth
   let host: String
   let service: String
   let ssl_mode: SSLMode
   let auth_requirement: AuthRequirement
-  let connection_timeout: (lori.ConnectionTimeout | None)
+  let connection_timeout: (net.ConnectionTimeout | None)
 
   new val create(
-    auth': lori.TCPConnectAuth,
+    auth': net.TCPConnectAuth,
     host': String,
     service': String,
     ssl_mode': SSLMode = SSLDisabled,
     auth_requirement': AuthRequirement = AuthRequireSCRAM,
-    connection_timeout': (lori.ConnectionTimeout | None) = None)
+    connection_timeout': (net.ConnectionTimeout | None) = None)
   =>
     auth = auth'
     host = host'

--- a/postgres/session.pony
+++ b/postgres/session.pony
@@ -1,10 +1,10 @@
 use "buffered"
 use "encode/base64"
-use lori = "lori"
+use net = "net"
 use "ssl/crypto"
 
 
-actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+actor Session is (net.TCPConnectionActor & net.ClientLifecycleEventReceiver)
   """
   The main entry point for interacting with a PostgreSQL server. Manages the
   connection lifecycle — connecting, authenticating, executing queries, and
@@ -27,10 +27,10 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   Most operations accept an optional `statement_timeout` parameter. When
   provided, the driver automatically sends a CancelRequest if the operation
   does not complete within the given duration. Construct the timeout with
-  `lori.MakeTimerDuration(milliseconds)`.
+  `net.MakeTimerDuration(milliseconds)`.
   """
   var state: _SessionState
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _tcp_connection: net.TCPConnection = net.TCPConnection.none()
   let _server_connect_info: ServerConnectInfo
 
   new create(
@@ -49,7 +49,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
         registry)
 
     _tcp_connection =
-      lori.TCPConnection.client(
+      net.TCPConnection.client(
         server_connect_info'.auth,
         server_connect_info'.host,
         server_connect_info'.service,
@@ -63,7 +63,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   be execute(
     query: Query,
     receiver: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     """
     Execute a query. If `statement_timeout` is provided, the query will be
@@ -76,7 +76,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     """
     Prepare a named server-side statement. The SQL string must contain a single
@@ -110,7 +110,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   be copy_in(
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     """
     Start a COPY ... FROM STDIN operation. The SQL string should be a COPY
@@ -148,7 +148,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   be copy_out(
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     """
     Start a COPY ... TO STDOUT operation. The SQL string should be a COPY
@@ -164,7 +164,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     """
     Start a streaming query that delivers rows in windowed batches via
@@ -202,7 +202,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
 
   be pipeline(queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     """
     Execute multiple queries in a single pipeline. All queries are sent to the
@@ -231,7 +231,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   be _process_again() =>
     state.process_responses(this)
 
-  fun ref _on_timer(token: lori.TimerToken) =>
+  fun ref _on_timer(token: net.TimerToken) =>
     state.on_timer(this, token)
 
   fun ref _on_timer_failure() =>
@@ -257,7 +257,7 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     _on_timer_failure()
 
   fun ref _on_idle_timer_failure() =>
-    // postgres never arms lori's idle timer, so this callback firing is a
+    // postgres never arms net's idle timer, so this callback firing is a
     // contract violation.
     _IllegalState()
 
@@ -265,32 +265,32 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     state.on_connected(this)
 
   fun ref _on_connection_failure(
-    reason: lori.ConnectionFailureReason)
+    reason: net.ConnectionFailureReason)
   =>
     let r: ConnectionFailureReason =
       match \exhaustive\ reason
-      | let _: lori.ConnectionFailedDNS =>
+      | let _: net.ConnectionFailedDNS =>
         ConnectionFailedDNS
-      | let _: lori.ConnectionFailedTCP =>
+      | let _: net.ConnectionFailedTCP =>
         ConnectionFailedTCP
-      | let _: lori.ConnectionFailedSSL =>
+      | let _: net.ConnectionFailedSSL =>
         TLSHandshakeFailed
-      | let _: lori.ConnectionFailedTimeout =>
+      | let _: net.ConnectionFailedTimeout =>
         ConnectionFailedTimeout
-      | let _: lori.ConnectionFailedTimerError =>
+      | let _: net.ConnectionFailedTimerError =>
         ConnectionFailedTimerError
       end
     state.on_connection_failed(this, r)
 
-  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+  fun ref _on_received(data: Array[U8] iso): net.ReadAction =>
     state.on_received(this, consume data)
-    lori.KeepReading
+    net.KeepReading
 
   // Routed through the state machine. Each state handles peer close
   // through its own `on_closed` — pre-ready states deliver
   // `pg_session_connection_failed(ConnectionClosedByServer)`;
   // `_SessionLoggedIn` notifies any in-flight query; `_SessionClosed`
-  // is a no-op so lori's follow-up after user-initiated close or TLS
+  // is a no-op so net's follow-up after user-initiated close or TLS
   // failure does not double-notify.
   fun ref _on_closed() =>
     state.on_closed(this)
@@ -299,16 +299,16 @@ actor Session is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
     state.on_tls_ready(this)
 
   fun ref _on_tls_failure(
-    reason: lori.TLSFailureReason)
+    reason: net.TLSFailureReason)
   =>
     let r: ConnectionFailureReason =
       match \exhaustive\ reason
-      | let _: lori.TLSAuthFailed => TLSAuthFailed
-      | let _: lori.TLSGeneralError => TLSHandshakeFailed
+      | let _: net.TLSAuthFailed => TLSAuthFailed
+      | let _: net.TLSGeneralError => TLSHandshakeFailed
       end
     state.on_connection_failed(this, r)
 
-  fun ref _connection(): lori.TCPConnection =>
+  fun ref _connection(): net.TCPConnection =>
     _tcp_connection
 
   fun server_connect_info(): ServerConnectInfo =>
@@ -339,7 +339,7 @@ class ref _SessionUnopened is _ConnectableState
     s: Session ref,
     q: Query,
     r: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     r.pg_query_failed(s, q, SessionNeverOpened)
 
@@ -348,7 +348,7 @@ class ref _SessionUnopened is _ConnectableState
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_prepare_failed(s, name, SessionNeverOpened)
 
@@ -356,7 +356,7 @@ class ref _SessionUnopened is _ConnectableState
     s: Session ref,
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNeverOpened)
 
@@ -364,7 +364,7 @@ class ref _SessionUnopened is _ConnectableState
     s: Session ref,
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNeverOpened)
 
@@ -373,7 +373,7 @@ class ref _SessionUnopened is _ConnectableState
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_stream_failed(s, query, SessionNeverOpened)
 
@@ -381,7 +381,7 @@ class ref _SessionUnopened is _ConnectableState
     s: Session ref,
     queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     for (i, q) in queries.pairs() do
       receiver.pg_pipeline_failed(s, i, q, SessionNeverOpened)
@@ -410,7 +410,7 @@ class ref _SessionUnopened is _ConnectableState
     _IllegalState()
 
   fun ref on_closed(s: Session ref) =>
-    // No TCP connection has ever existed in this state — lori cannot fire
+    // No TCP connection has ever existed in this state —net cannot fire
     // `_on_closed` before `_on_connected` or `_on_connection_failure`.
     _IllegalState()
 
@@ -419,7 +419,7 @@ class ref _SessionClosed is (_NotConnectableState & _UnconnectedState)
     s: Session ref,
     q: Query,
     r: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     r.pg_query_failed(s, q, SessionClosed)
 
@@ -428,7 +428,7 @@ class ref _SessionClosed is (_NotConnectableState & _UnconnectedState)
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_prepare_failed(s, name, SessionClosed)
 
@@ -436,7 +436,7 @@ class ref _SessionClosed is (_NotConnectableState & _UnconnectedState)
     s: Session ref,
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionClosed)
 
@@ -444,7 +444,7 @@ class ref _SessionClosed is (_NotConnectableState & _UnconnectedState)
     s: Session ref,
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionClosed)
 
@@ -453,7 +453,7 @@ class ref _SessionClosed is (_NotConnectableState & _UnconnectedState)
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_stream_failed(s, query, SessionClosed)
 
@@ -461,7 +461,7 @@ class ref _SessionClosed is (_NotConnectableState & _UnconnectedState)
     s: Session ref,
     queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     for (i, q) in queries.pairs() do
       receiver.pg_pipeline_failed(s, i, q, SessionClosed)
@@ -481,9 +481,9 @@ class ref _SessionClosed is (_NotConnectableState & _UnconnectedState)
 
   fun ref on_closed(s: Session ref) =>
     // Reachable after the session has already shut down and transitioned
-    // here: either user-initiated close (lori fires `_on_closed` after
+    // here: either user-initiated close (net fires `_on_closed` after
     // the resulting `hard_close()`), or a TLS-handshake failure where
-    // lori fires `_on_tls_failure` followed by `_on_closed`. Firing
+    // net fires `_on_tls_failure` followed by `_on_closed`. Firing
     // callbacks again would double-notify the application.
     None
 
@@ -504,7 +504,7 @@ class ref _SessionSSLNegotiating
   """
   let _notify: SessionStatusNotify
   let _database_connect_info: DatabaseConnectInfo
-  let _ssl_ctx: lori.SSLContext val
+  let _ssl_ctx: net.SSLContext val
   let _host: String
   let _fallback_on_refusal: Bool
   let _codec_registry: CodecRegistry
@@ -513,7 +513,7 @@ class ref _SessionSSLNegotiating
   new ref create(
     notify': SessionStatusNotify,
     database_connect_info': DatabaseConnectInfo,
-    ssl_ctx': lori.SSLContext val,
+    ssl_ctx': net.SSLContext val,
     host': String,
     fallback_on_refusal': Bool,
     codec_registry': CodecRegistry = CodecRegistry)
@@ -531,9 +531,9 @@ class ref _SessionSSLNegotiating
 
   fun ref on_received(s: Session ref, data: Array[U8] iso) =>
     if _handshake_started then
-      // Invariant: lori handles socket I/O during the TLS handshake and does
+      // Invariant:net handles socket I/O during the TLS handshake and does
       // not deliver application data until on_tls_ready fires. Reaching this
-      // branch means lori's contract has been violated — a crash is the
+      // branch means net's contract has been violated — a crash is the
       // correct response.
       _IllegalState()
     end
@@ -544,7 +544,7 @@ class ref _SessionSSLNegotiating
         match \exhaustive\ s._connection().start_tls(_ssl_ctx, _host)
         | None =>
           _handshake_started = true
-        | let _: lori.StartTLSError =>
+        | let _: net.StartTLSError =>
           _connection_failed(s, TLSHandshakeFailed)
         end
       elseif response == 'N' then
@@ -565,10 +565,10 @@ class ref _SessionSSLNegotiating
 
   fun ref _proceed_to_connected(s: Session ref) =>
     // Reset buffer_until from 1 (set during SSLRequest) to streaming (deliver
-    // all available bytes). Critical: lori preserves the buffer_until value
+    // all available bytes). Critical:net preserves the buffer_until value
     // across start_tls(). Without this reset, decrypted data would be delivered
     // 1 byte at a time, breaking _ResponseParser.
-    s._connection().buffer_until(lori.Streaming)
+    s._connection().buffer_until(net.Streaming)
     s.state =
       _SessionConnected(
         _notify, _database_connect_info, _codec_registry)
@@ -583,7 +583,7 @@ class ref _SessionSSLNegotiating
     reason: ConnectionFailureReason)
   =>
     """
-    Entry point for failures reported by lori — the TLS handshake failure
+    Entry point for failures reported bynet — the TLS handshake failure
     path (Session._on_tls_failure) and the peer-close path
     (Session._on_closed, routed via `on_closed` below). Lori has already
     closed the TCP connection on its side by the time this fires, so we
@@ -604,7 +604,7 @@ class ref _SessionSSLNegotiating
     s: Session ref,
     q: Query,
     r: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     r.pg_query_failed(s, q, SessionNotAuthenticated)
 
@@ -613,7 +613,7 @@ class ref _SessionSSLNegotiating
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_prepare_failed(s, name, SessionNotAuthenticated)
 
@@ -621,7 +621,7 @@ class ref _SessionSSLNegotiating
     s: Session ref,
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNotAuthenticated)
 
@@ -629,7 +629,7 @@ class ref _SessionSSLNegotiating
     s: Session ref,
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNotAuthenticated)
 
@@ -638,7 +638,7 @@ class ref _SessionSSLNegotiating
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_stream_failed(s, query, SessionNotAuthenticated)
 
@@ -646,7 +646,7 @@ class ref _SessionSSLNegotiating
     s: Session ref,
     queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     for (i, q) in queries.pairs() do
       receiver.pg_pipeline_failed(s, i, q, SessionNotAuthenticated)
@@ -685,7 +685,7 @@ class ref _SessionSSLNegotiating
   fun ref cancel(s: Session ref) =>
     None
 
-  fun ref on_timer(s: Session ref, token: lori.TimerToken) =>
+  fun ref on_timer(s: Session ref, token: net.TimerToken) =>
     None
 
   fun ref on_timer_failure(s: Session ref) =>
@@ -712,7 +712,7 @@ class ref _SessionSSLNegotiating
     is still live, so this helper closes it before firing the failure and
     shutdown callbacks.
 
-    For failures reported by lori (where lori has already closed the TCP
+    For failures reported bynet (wherenet has already closed the TCP
     connection), use `on_connection_failed` instead.
     """
     s._connection().close()
@@ -748,7 +748,7 @@ class ref _SessionConnected is _AuthenticableState
     s: Session ref,
     q: Query,
     r: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     r.pg_query_failed(s, q, SessionNotAuthenticated)
 
@@ -757,7 +757,7 @@ class ref _SessionConnected is _AuthenticableState
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_prepare_failed(s, name, SessionNotAuthenticated)
 
@@ -765,7 +765,7 @@ class ref _SessionConnected is _AuthenticableState
     s: Session ref,
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNotAuthenticated)
 
@@ -773,7 +773,7 @@ class ref _SessionConnected is _AuthenticableState
     s: Session ref,
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNotAuthenticated)
 
@@ -782,7 +782,7 @@ class ref _SessionConnected is _AuthenticableState
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_stream_failed(s, query, SessionNotAuthenticated)
 
@@ -790,7 +790,7 @@ class ref _SessionConnected is _AuthenticableState
     s: Session ref,
     queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     for (i, q) in queries.pairs() do
       receiver.pg_pipeline_failed(s, i, q, SessionNotAuthenticated)
@@ -992,7 +992,7 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
     s: Session ref,
     q: Query,
     r: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     r.pg_query_failed(s, q, SessionNotAuthenticated)
 
@@ -1001,7 +1001,7 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_prepare_failed(s, name, SessionNotAuthenticated)
 
@@ -1009,7 +1009,7 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
     s: Session ref,
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNotAuthenticated)
 
@@ -1017,7 +1017,7 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
     s: Session ref,
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_copy_failed(s, SessionNotAuthenticated)
 
@@ -1026,7 +1026,7 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     receiver.pg_stream_failed(s, query, SessionNotAuthenticated)
 
@@ -1034,7 +1034,7 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
     s: Session ref,
     queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     for (i, q) in queries.pairs() do
       receiver.pg_pipeline_failed(s, i, q, SessionNotAuthenticated)
@@ -1065,12 +1065,12 @@ class ref _SessionSCRAMAuthenticating is (_ConnectedState & _NotAuthenticated)
 class val _QueuedQuery
   let query: Query
   let receiver: ResultReceiver
-  let statement_timeout: (lori.TimerDuration | None)
+  let statement_timeout: (net.TimerDuration | None)
 
   new val create(
     query': Query,
     receiver': ResultReceiver,
-    statement_timeout': (lori.TimerDuration | None) = None)
+    statement_timeout': (net.TimerDuration | None) = None)
   =>
     query = query'
     receiver = receiver'
@@ -1080,13 +1080,13 @@ class val _QueuedPrepare
   let name: String
   let sql: String
   let receiver: PrepareReceiver
-  let statement_timeout: (lori.TimerDuration | None)
+  let statement_timeout: (net.TimerDuration | None)
 
   new val create(
     name': String,
     sql': String,
     receiver': PrepareReceiver,
-    statement_timeout': (lori.TimerDuration | None) = None)
+    statement_timeout': (net.TimerDuration | None) = None)
   =>
     name = name'
     sql = sql'
@@ -1102,12 +1102,12 @@ class val _QueuedCloseStatement
 class val _QueuedCopyIn
   let sql: String
   let receiver: CopyInReceiver
-  let statement_timeout: (lori.TimerDuration | None)
+  let statement_timeout: (net.TimerDuration | None)
 
   new val create(
     sql': String,
     receiver': CopyInReceiver,
-    statement_timeout': (lori.TimerDuration | None) = None)
+    statement_timeout': (net.TimerDuration | None) = None)
   =>
     sql = sql'
     receiver = receiver'
@@ -1116,12 +1116,12 @@ class val _QueuedCopyIn
 class val _QueuedCopyOut
   let sql: String
   let receiver: CopyOutReceiver
-  let statement_timeout: (lori.TimerDuration | None)
+  let statement_timeout: (net.TimerDuration | None)
 
   new val create(
     sql': String,
     receiver': CopyOutReceiver,
-    statement_timeout': (lori.TimerDuration | None) = None)
+    statement_timeout': (net.TimerDuration | None) = None)
   =>
     sql = sql'
     receiver = receiver'
@@ -1134,13 +1134,13 @@ class val _QueuedStreamingQuery
   let query: (PreparedQuery | NamedPreparedQuery)
   let window_size: U32
   let receiver: StreamingResultReceiver
-  let statement_timeout: (lori.TimerDuration | None)
+  let statement_timeout: (net.TimerDuration | None)
 
   new val create(
     query': (PreparedQuery | NamedPreparedQuery),
     window_size': U32,
     receiver': StreamingResultReceiver,
-    statement_timeout': (lori.TimerDuration | None) = None)
+    statement_timeout': (net.TimerDuration | None) = None)
   =>
     query = query'
     window_size = window_size'
@@ -1153,12 +1153,12 @@ class val _QueuedPipeline
   """
   let queries: Array[(PreparedQuery | NamedPreparedQuery)] val
   let receiver: PipelineReceiver
-  let statement_timeout: (lori.TimerDuration | None)
+  let statement_timeout: (net.TimerDuration | None)
 
   new val create(
     queries': Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver': PipelineReceiver,
-    statement_timeout': (lori.TimerDuration | None) = None)
+    statement_timeout': (net.TimerDuration | None) = None)
   =>
     queries = queries'
     receiver = receiver'
@@ -1188,7 +1188,7 @@ class _SessionLoggedIn is _AuthenticatedState
   var backend_pid: I32 = 0
   var backend_secret_key: I32 = 0
   let codec_registry: CodecRegistry
-  var statement_timer: (lori.TimerToken | None) = None
+  var statement_timer: (net.TimerToken | None) = None
   let _notify: SessionStatusNotify
   let _readbuf: Reader
 
@@ -1256,9 +1256,9 @@ class _SessionLoggedIn is _AuthenticatedState
     _notify.pg_session_shutdown(s)
     s.state = _SessionClosed
 
-  fun ref on_timer(s: Session ref, token: lori.TimerToken) =>
+  fun ref on_timer(s: Session ref, token: net.TimerToken) =>
     match statement_timer
-    | let t: lori.TimerToken if t == token =>
+    | let t: net.TimerToken if t == token =>
       statement_timer = None
       _CancelSender(s.server_connect_info(), backend_pid, backend_secret_key)
     end
@@ -1283,21 +1283,21 @@ class _SessionLoggedIn is _AuthenticatedState
         | let pl: _QueuedPipeline => pl.statement_timeout
         end
       match timeout
-      | let d: lori.TimerDuration =>
+      | let d: net.TimerDuration =>
         match \exhaustive\ s._connection().set_timer(d)
-        | let t: lori.TimerToken => statement_timer = t
-        | let _: lori.SetTimerError => None
+        | let t: net.TimerToken => statement_timer = t
+        | let _: net.SetTimerError => None
         end
       end
     end
-    // Empty queue is an invariant violation for a real lori dispatch (the
+    // Empty queue is an invariant violation for a realnet dispatch (the
     // timer is only armed while a queue item is at the head), but the
     // interface's "never illegal, silently ignore" contract still applies.
     // Silently no-op rather than panic.
 
   fun ref cancel_statement_timer(s: Session ref) =>
     match statement_timer
-    | let t: lori.TimerToken =>
+    | let t: net.TimerToken =>
       s._connection().cancel_timer(t)
       statement_timer = None
     end
@@ -1316,7 +1316,7 @@ class _SessionLoggedIn is _AuthenticatedState
   fun ref execute(s: Session ref,
     query: Query,
     receiver: ResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     query_queue.push(_QueuedQuery(query, receiver, statement_timeout))
     query_state.try_run_query(s, this)
@@ -1326,7 +1326,7 @@ class _SessionLoggedIn is _AuthenticatedState
     name: String,
     sql: String,
     receiver: PrepareReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     query_queue.push(_QueuedPrepare(name, sql, receiver, statement_timeout))
     query_state.try_run_query(s, this)
@@ -1339,7 +1339,7 @@ class _SessionLoggedIn is _AuthenticatedState
     s: Session ref,
     sql: String,
     receiver: CopyInReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     query_queue.push(_QueuedCopyIn(sql, receiver, statement_timeout))
     query_state.try_run_query(s, this)
@@ -1348,7 +1348,7 @@ class _SessionLoggedIn is _AuthenticatedState
     s: Session ref,
     sql: String,
     receiver: CopyOutReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     query_queue.push(_QueuedCopyOut(sql, receiver, statement_timeout))
     query_state.try_run_query(s, this)
@@ -1358,7 +1358,7 @@ class _SessionLoggedIn is _AuthenticatedState
     query: (PreparedQuery | NamedPreparedQuery),
     window_size: U32,
     receiver: StreamingResultReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     query_queue.push(
       _QueuedStreamingQuery(query, window_size, receiver, statement_timeout))
@@ -1368,7 +1368,7 @@ class _SessionLoggedIn is _AuthenticatedState
     s: Session ref,
     queries: Array[(PreparedQuery | NamedPreparedQuery)] val,
     receiver: PipelineReceiver,
-    statement_timeout: (lori.TimerDuration | None) = None)
+    statement_timeout: (net.TimerDuration | None) = None)
   =>
     query_queue.push(_QueuedPipeline(queries, receiver, statement_timeout))
     query_state.try_run_query(s, this)

--- a/postgres/ssl_mode.pony
+++ b/postgres/ssl_mode.pony
@@ -1,4 +1,4 @@
-use lori = "lori"
+use net = "net"
 
 primitive SSLDisabled
   """
@@ -18,18 +18,18 @@ class val SSLPreferred
   matching PostgreSQL's `sslmode=prefer` behavior.
 
   The `SSLContext` controls certificate and cipher configuration. Users must
-  `use lori = "lori"` in their own code to create an `SSLContext val`:
+  `use "net"` in their own code to create an `SSLContext val`:
 
       let sslctx = recover val
-        lori.SSLContext
+        SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
       SSLPreferred(sslctx)
   """
-  let ctx: lori.SSLContext val
+  let ctx: net.SSLContext val
 
-  new val create(ctx': lori.SSLContext val) =>
+  new val create(ctx': net.SSLContext val) =>
     ctx = ctx'
 
 class val SSLRequired
@@ -39,18 +39,18 @@ class val SSLRequired
   authentication begins.
 
   The `SSLContext` controls certificate and cipher configuration. Users must
-  `use lori = "lori"` in their own code to create an `SSLContext val`:
+  `use "net"` in their own code to create an `SSLContext val`:
 
       let sslctx = recover val
-        lori.SSLContext
+        SSLContext
           .> set_client_verify(false)
           .> set_server_verify(false)
       end
       SSLRequired(sslctx)
   """
-  let ctx: lori.SSLContext val
+  let ctx: net.SSLContext val
 
-  new val create(ctx': lori.SSLContext val) =>
+  new val create(ctx': net.SSLContext val) =>
     ctx = ctx'
 
 type SSLMode is (SSLDisabled | SSLPreferred | SSLRequired)


### PR DESCRIPTION
Lori has been merged into ponyc's stdlib as the `net` package. This switches postgres from the external lori dependency to stdlib net.

postgres uses a qualified import (`use net = "net"`) because it defines its own wider `ConnectionFailureReason` union that includes postgres-specific failure types alongside the base connection failure types from net.

- Remove lori from `corral.json` (ssl dependency stays — postgres uses `ssl/crypto`)
- Switch all `use lori = "lori"` to `use net = "net"` and all `lori.` qualifiers to `net.`
- Update user-facing docstring examples to show unqualified `use "net"`
- Update CI from `:release` to `:nightly` ponyc
- Bump minimum ponyc version to 0.72.0
